### PR TITLE
Bm0418 fix skip consent

### DIFF
--- a/backbone/build.gradle
+++ b/backbone/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'com.neenbedankt.android-apt'
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 
-version = '1.0.0.rc1-tl'
+version = '1.0.0.rc1'
 
 android {
     compileSdkVersion 23

--- a/skin/build.gradle
+++ b/skin/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'me.tatarka.retrolambda'
 apply plugin: 'com.neenbedankt.android-apt'
 apply plugin: 'com.jfrog.bintray'
 
-version = '1.0.0.rc1-tl'
+version = '1.0.0.rc1'
 
 android {
     compileSdkVersion 23

--- a/skin/src/main/java/org/researchstack/skin/ui/ConsentTaskActivity.java
+++ b/skin/src/main/java/org/researchstack/skin/ui/ConsentTaskActivity.java
@@ -3,15 +3,15 @@ import android.content.Context;
 import android.content.Intent;
 
 import org.researchstack.backbone.StorageAccess;
+import org.researchstack.backbone.task.Task;
 import org.researchstack.backbone.ui.ViewTaskActivity;
-import org.researchstack.skin.TaskProvider;
 
 public class ConsentTaskActivity extends ViewTaskActivity
 {
-    public static Intent newIntent(Context context)
+    public static Intent newIntent(Context context, Task task)
     {
         Intent intent = new Intent(context, ConsentTaskActivity.class);
-        intent.putExtra(EXTRA_TASK, TaskProvider.getInstance().get(TaskProvider.TASK_ID_CONSENT));
+        intent.putExtra(EXTRA_TASK, task);
         return intent;
     }
 

--- a/skin/src/main/java/org/researchstack/skin/ui/OnboardingActivity.java
+++ b/skin/src/main/java/org/researchstack/skin/ui/OnboardingActivity.java
@@ -228,7 +228,8 @@ public class OnboardingActivity extends PinCodeActivity implements View.OnClickL
             PassCodeCreationStep step = new PassCodeCreationStep(OnboardingTask.SignUpPassCodeCreationStepIdentifier,
                     R.string.rss_passcode);
             OrderedTask task = new OrderedTask("PasscodeTask", step);
-            startActivityForResult(ViewTaskActivity.newIntent(this, task), REQUEST_CODE_PASSCODE);
+            startActivityForResult(ConsentTaskActivity.newIntent(this, task),
+                    REQUEST_CODE_PASSCODE);
         }
         else
         {

--- a/skin/src/main/java/org/researchstack/skin/ui/SignUpTaskActivity.java
+++ b/skin/src/main/java/org/researchstack/skin/ui/SignUpTaskActivity.java
@@ -19,6 +19,7 @@ import org.researchstack.backbone.utils.TextUtils;
 import org.researchstack.skin.DataProvider;
 import org.researchstack.skin.PermissionRequestManager;
 import org.researchstack.skin.R;
+import org.researchstack.skin.TaskProvider;
 import org.researchstack.skin.task.OnboardingTask;
 import org.researchstack.skin.ui.layout.SignUpEligibleStepLayout;
 
@@ -76,7 +77,8 @@ public class SignUpTaskActivity extends ViewTaskActivity implements ActivityCall
     @Override
     public void startConsentTask()
     {
-        Intent intent = ConsentTaskActivity.newIntent(this);
+        Intent intent = ConsentTaskActivity.newIntent(this,
+                TaskProvider.getInstance().get(TaskProvider.TASK_ID_CONSENT));
         startActivityForResult(intent, SignUpEligibleStepLayout.CONSENT_REQUEST);
     }
 


### PR DESCRIPTION
Allows the ConsentTaskActivity (which can show tasks before a pincode has been entered by the user) to show the pincode creation step when skipping consent.