### PR TITLE
Bm0419 make toasts longer

### DIFF
--- a/backbone/build.gradle
+++ b/backbone/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'com.neenbedankt.android-apt'
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 
-version = '1.0.0.rc1-tl'
+version = '1.0.0.rc1'
 
 android {
     compileSdkVersion 23

--- a/skin/build.gradle
+++ b/skin/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'me.tatarka.retrolambda'
 apply plugin: 'com.neenbedankt.android-apt'
 apply plugin: 'com.jfrog.bintray'
 
-version = '1.0.0.rc1-tl'
+version = '1.0.0.rc1'
 
 android {
     compileSdkVersion 23

--- a/skin/src/main/java/org/researchstack/skin/ui/EmailVerificationActivity.java
+++ b/skin/src/main/java/org/researchstack/skin/ui/EmailVerificationActivity.java
@@ -141,7 +141,7 @@ public class EmailVerificationActivity extends PinCodeActivity
                     progress.animate()
                             .alpha(0)
                             .withEndAction(() -> progress.setVisibility(View.GONE));
-                    Toast.makeText(this, dataResponse.getMessage(), Toast.LENGTH_SHORT).show();
+                    Toast.makeText(this, dataResponse.getMessage(), Toast.LENGTH_LONG).show();
                 }, throwable -> {
                     // Convert errorBody to JSON-String, convert json-string to object
                     // (BridgeMessageResponse) and pass BridgeMessageResponse.getMessage()to
@@ -149,7 +149,7 @@ public class EmailVerificationActivity extends PinCodeActivity
                     progress.animate()
                             .alpha(0)
                             .withEndAction(() -> progress.setVisibility(View.GONE));
-                    Toast.makeText(this, throwable.getMessage(), Toast.LENGTH_SHORT).show();
+                    Toast.makeText(this, throwable.getMessage(), Toast.LENGTH_LONG).show();
                 });
     }
 
@@ -181,16 +181,14 @@ public class EmailVerificationActivity extends PinCodeActivity
                                 .alpha(0)
                                 .withEndAction(() -> progress.setVisibility(View.GONE));
                         Toast.makeText(EmailVerificationActivity.this,
-                                R.string.rss_email_not_verified,
-                                Toast.LENGTH_SHORT).show();
+                                R.string.rss_email_not_verified, Toast.LENGTH_LONG).show();
                     }
                 }, error -> {
                     progress.animate()
                             .alpha(0)
                             .withEndAction(() -> progress.setVisibility(View.GONE));
                     Toast.makeText(EmailVerificationActivity.this,
-                            R.string.rss_email_not_verified,
-                            Toast.LENGTH_SHORT).show();
+                            R.string.rss_email_not_verified, Toast.LENGTH_LONG).show();
                 });
     }
 }


### PR DESCRIPTION
The feedback from trying to resend a confirmation email was too quick and couldn't be read easily. Made it longer