### PR TITLE
Fixed result not selected when going back to Duration Question Step

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/body/DurationQuestionBody.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/body/DurationQuestionBody.java
@@ -107,6 +107,12 @@ public class DurationQuestionBody implements StepBody
         minutesSpinner = (Spinner) v.findViewById(R.id.minutes);
         minutesSpinner.setAdapter(minutesChoices);
 
+        Integer result = this.result.getResult();
+        if(result != null){
+            hoursSpinner.setSelection(result/60);
+            minutesSpinner.setSelection(result%60);
+        }
+
         return v;
     }
 


### PR DESCRIPTION
When selecting a duration, going forward to the next step and then pushing back the previously selected values where not show.
