### PR TITLE
feature/consent_quiz_items_field

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/model/ConsentQuestionType.java
+++ b/backbone/src/main/java/org/researchstack/backbone/model/ConsentQuestionType.java
@@ -1,0 +1,26 @@
+package org.researchstack.backbone.model;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Created by TheMDP on 12/15/16.
+ */
+
+public enum ConsentQuestionType {
+
+    @SerializedName("boolean")
+    BOOLEAN("boolean"),
+    @SerializedName("singleChoiceText")
+    SINGLE_CHOICE_TEXT("singleChoiceText"),
+    @SerializedName("instruction")
+    INSTRUCTION("instruction");
+
+    ConsentQuestionType(String questionId) {
+        mIdentifier = questionId;
+    }
+
+    String mIdentifier;
+    public String getIdentifier() {
+        return mIdentifier;
+    }
+}

--- a/backbone/src/main/java/org/researchstack/backbone/model/ConsentQuizModel.java
+++ b/backbone/src/main/java/org/researchstack/backbone/model/ConsentQuizModel.java
@@ -1,4 +1,4 @@
-package org.researchstack.skin.model;
+package org.researchstack.backbone.model;
 
 import java.io.Serializable;
 import java.util.List;
@@ -60,12 +60,23 @@ public class ConsentQuizModel implements Serializable
     {
         private String       identifier;
         private String       prompt;
-        private String       type;
+        private ConsentQuestionType type;
         private String       expectedAnswer;
         private String       text;
-        private List<String> textChoices;
         private String       positiveFeedback;
         private String       negativeFeedback;
+
+        /**
+         * There are multiple ways you can provide the options for a quiz question:
+         * textChoices - a simple String list of choices for the user, the answer
+         *               format will be the index in the array of the selected item
+         */
+        private List<String> textChoices;
+        /**
+         * There are multiple ways you can provide the options for a quiz question:
+         * items - a list of text / value pairs that can provide any type of answer value per text
+         */
+        private List<Choice> items;
 
         public String getIdentifier()
         {
@@ -82,7 +93,7 @@ public class ConsentQuizModel implements Serializable
             return prompt;
         }
 
-        public String getType()
+        public ConsentQuestionType getType()
         {
             return type;
         }
@@ -100,6 +111,10 @@ public class ConsentQuizModel implements Serializable
         public List<String> getTextChoices()
         {
             return textChoices;
+        }
+
+        public List<Choice> getItems() {
+            return items;
         }
 
         public String getPositiveFeedback()

--- a/backbone/src/main/java/org/researchstack/backbone/model/ConsentQuizModel.java
+++ b/backbone/src/main/java/org/researchstack/backbone/model/ConsentQuizModel.java
@@ -1,5 +1,7 @@
 package org.researchstack.backbone.model;
 
+import com.google.gson.annotations.SerializedName;
+
 import java.io.Serializable;
 import java.util.List;
 
@@ -59,7 +61,11 @@ public class ConsentQuizModel implements Serializable
     public class QuizQuestion implements Serializable
     {
         private String       identifier;
+
+        /** iOS named it "title" but Android named it prompt, so allow for parsing of both */
+        @SerializedName(value="prompt", alternate = {"title"})
         private String       prompt;
+
         private ConsentQuestionType type;
         private String       expectedAnswer;
         private String       text;

--- a/skin/src/main/java/org/researchstack/skin/model/ConsentSectionModel.java
+++ b/skin/src/main/java/org/researchstack/skin/model/ConsentSectionModel.java
@@ -1,6 +1,7 @@
 package org.researchstack.skin.model;
 import com.google.gson.annotations.SerializedName;
 
+import org.researchstack.backbone.model.ConsentQuizModel;
 import org.researchstack.backbone.model.ConsentSection;
 import org.researchstack.backbone.model.DocumentProperties;
 

--- a/skin/src/main/java/org/researchstack/skin/step/ConsentQuizEvaluationStep.java
+++ b/skin/src/main/java/org/researchstack/skin/step/ConsentQuizEvaluationStep.java
@@ -2,7 +2,7 @@ package org.researchstack.skin.step;
 
 import org.researchstack.backbone.step.Step;
 import org.researchstack.skin.R;
-import org.researchstack.skin.model.ConsentQuizModel;
+import org.researchstack.backbone.model.ConsentQuizModel;
 import org.researchstack.skin.ui.layout.ConsentQuizEvaluationStepLayout;
 
 public class ConsentQuizEvaluationStep extends Step

--- a/skin/src/main/java/org/researchstack/skin/step/ConsentQuizQuestionStep.java
+++ b/skin/src/main/java/org/researchstack/skin/step/ConsentQuizQuestionStep.java
@@ -2,7 +2,7 @@ package org.researchstack.skin.step;
 
 import org.researchstack.backbone.step.Step;
 import org.researchstack.skin.R;
-import org.researchstack.skin.model.ConsentQuizModel;
+import org.researchstack.backbone.model.ConsentQuizModel;
 import org.researchstack.skin.ui.layout.ConsentQuizQuestionStepLayout;
 
 public class ConsentQuizQuestionStep extends Step

--- a/skin/src/main/java/org/researchstack/skin/task/ConsentTask.java
+++ b/skin/src/main/java/org/researchstack/skin/task/ConsentTask.java
@@ -27,7 +27,7 @@ import org.researchstack.backbone.utils.LogExt;
 import org.researchstack.backbone.utils.TextUtils;
 import org.researchstack.skin.R;
 import org.researchstack.skin.ResourceManager;
-import org.researchstack.skin.model.ConsentQuizModel;
+import org.researchstack.backbone.model.ConsentQuizModel;
 import org.researchstack.skin.model.ConsentSectionModel;
 import org.researchstack.skin.step.ConsentQuizEvaluationStep;
 import org.researchstack.skin.step.ConsentQuizQuestionStep;

--- a/skin/src/main/java/org/researchstack/skin/utils/ConsentQuizQuestionUtils.java
+++ b/skin/src/main/java/org/researchstack/skin/utils/ConsentQuizQuestionUtils.java
@@ -12,6 +12,8 @@ import java.util.List;
 
 /**
  * Created by TheMDP on 12/15/16.
+ *
+ * This class the business logic of interacting with the ConsentQuizModel object
  */
 
 public class ConsentQuizQuestionUtils {

--- a/skin/src/main/java/org/researchstack/skin/utils/ConsentQuizQuestionUtils.java
+++ b/skin/src/main/java/org/researchstack/skin/utils/ConsentQuizQuestionUtils.java
@@ -1,0 +1,62 @@
+package org.researchstack.skin.utils;
+
+import android.content.Context;
+import android.util.Log;
+
+import org.researchstack.skin.R;
+import org.researchstack.backbone.model.Choice;
+import org.researchstack.backbone.model.ConsentQuizModel;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by TheMDP on 12/15/16.
+ */
+
+public class ConsentQuizQuestionUtils {
+
+    static final String LOG_TAG = ConsentQuizQuestionUtils.class.getCanonicalName();
+
+    /**
+     * @param ctx - Used to access String resources when building question Strings
+     * @param question - Question to create choices from
+     * @return A list of choices which can be fabricated in various ways
+     */
+    public static List<Choice> createChoices(Context ctx, ConsentQuizModel.QuizQuestion question) {
+
+        if (question == null) {
+            Log.e(LOG_TAG, "Question was null, returning empty list");
+            return new ArrayList<>();
+        }
+
+        switch (question.getType()) {
+            case BOOLEAN:
+                return createBooleanChoices(ctx, question);
+            case SINGLE_CHOICE_TEXT:
+                return createSingleTextChoices(question);
+        }
+
+        return new ArrayList<>();
+    }
+
+    static List<Choice> createSingleTextChoices(ConsentQuizModel.QuizQuestion question) {
+        if (question.getItems() != null && !question.getItems().isEmpty()) {
+            return new ArrayList<>(question.getItems());
+        } else if (question.getTextChoices() != null && !question.getTextChoices().isEmpty()) {
+            List<Choice> choices = new ArrayList();
+            for (int i = 0; i < question.getTextChoices().size(); i++) {
+                choices.add(new Choice(question.getTextChoices().get(i), String.valueOf(i)));
+            }
+            return choices;
+        }
+        return new ArrayList<>();
+    }
+
+    static List<Choice> createBooleanChoices(Context ctx, ConsentQuizModel.QuizQuestion question) {
+        List<Choice> choices = new ArrayList();
+        choices.add(new Choice<>(ctx.getString(R.string.rss_btn_true), "true"));
+        choices.add(new Choice<>(ctx.getString(R.string.rss_btn_false), "false"));
+        return choices;
+    }
+}

--- a/skin/src/test/java/org/researchstack/skin/utils/ConsentQuizQuestionUtilsTest.java
+++ b/skin/src/test/java/org/researchstack/skin/utils/ConsentQuizQuestionUtilsTest.java
@@ -1,0 +1,97 @@
+package org.researchstack.skin.utils;
+
+import android.content.Context;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.researchstack.backbone.model.Choice;
+import org.researchstack.backbone.model.ConsentQuestionType;
+import org.researchstack.backbone.model.ConsentQuizModel;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Created by TheMDP on 12/15/16.
+ */
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConsentQuizQuestionUtilsTest {
+
+    Context mockContext;
+    ConsentQuizModel.QuizQuestion mockQuestion;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        mockContext = Mockito.mock(Context.class);
+        Mockito.when(mockContext.getString(org.researchstack.skin.R.string.rss_btn_true)).thenReturn("True");
+        Mockito.when(mockContext.getString(org.researchstack.skin.R.string.rss_btn_false)).thenReturn("False");
+    }
+
+    void resetQuestion(ConsentQuestionType type) {
+        mockQuestion = Mockito.mock(ConsentQuizModel.QuizQuestion.class);
+        Mockito.when(mockQuestion.getType()).thenReturn(type);
+    }
+
+    @Test
+    public void testBooleanChoiceCreation() {
+        resetQuestion(ConsentQuestionType.BOOLEAN);
+
+        List<Choice> expectedChoices = new ArrayList<>();
+        expectedChoices.add(new Choice("True", "true"));
+        expectedChoices.add(new Choice("False", "false"));
+
+        List<Choice> actualChoices = ConsentQuizQuestionUtils.createChoices(mockContext, mockQuestion);
+        assertChoiceListEquals(expectedChoices, actualChoices);
+    }
+
+    @Test
+    public void testSingleChoiceTextTextChoicesCreation() {
+        resetQuestion(ConsentQuestionType.SINGLE_CHOICE_TEXT);
+        List<String> textChoices = new ArrayList<>();
+        textChoices.add("A");
+        textChoices.add("B");
+        Mockito.when(mockQuestion.getTextChoices()).thenReturn(textChoices);
+
+        List<Choice> expectedChoices = new ArrayList<>();
+        expectedChoices.add(new Choice("A", "0"));
+        expectedChoices.add(new Choice("B", "1"));
+
+        List<Choice> actualChoices = ConsentQuizQuestionUtils.createChoices(mockContext, mockQuestion);
+        assertChoiceListEquals(expectedChoices, actualChoices);
+    }
+
+    @Test
+    public void testSingleChoiceTextItemsChoiceCreation() {
+        resetQuestion(ConsentQuestionType.SINGLE_CHOICE_TEXT);
+        List<Choice> expectedChoices = new ArrayList<>();
+        expectedChoices.add(new Choice("A", true));
+        expectedChoices.add(new Choice("B", false));
+        Mockito.when(mockQuestion.getItems()).thenReturn(expectedChoices);
+
+        List<Choice> actualChoices = ConsentQuizQuestionUtils.createChoices(mockContext, mockQuestion);
+        assertChoiceListEquals(expectedChoices, actualChoices);
+    }
+
+    void assertChoiceListEquals(List<Choice> expected, List<Choice> actual) {
+        assertNotNull(expected);
+        assertNotNull(actual);
+
+        assertEquals(expected.size(), actual.size());
+
+        for (int i = 0; i < expected.size(); i++) {
+            Choice expectedChoice = expected.get(i);
+            Choice actualChoice   = actual.get(i);
+            assertEquals(expectedChoice.getText(), actualChoice.getText());
+            assertEquals(expectedChoice.getValue(), actualChoice.getValue());
+            assertEquals(expectedChoice.getDetailText(), actualChoice.getDetailText());
+        }
+    }
+}


### PR DESCRIPTION
Added "items" parsing to consent json to keep compatibility with iOS.
Moved ConsentQuizModel to backbone, since it is a basic modal class
Also, added unit tests and new question utils class to decouple logic from step layout