### PR TITLE
Move cleanup from onDestroy to onPause

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/ui/PinCodeActivity.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/PinCodeActivity.java
@@ -45,6 +45,12 @@ public class PinCodeActivity extends AppCompatActivity implements StorageAccessL
         super.onPause();
         LogExt.i(getClass(), "logAccessTime()");
         StorageAccess.getInstance().logAccessTime();
+
+        storageAccessUnregister();
+        if(pinCodeLayout != null)
+        {
+            getWindowManager().removeView(pinCodeLayout);
+        }
     }
 
     @Override
@@ -53,17 +59,6 @@ public class PinCodeActivity extends AppCompatActivity implements StorageAccessL
         super.onResume();
 
         requestStorageAccess();
-    }
-
-    @Override
-    protected void onDestroy()
-    {
-        super.onDestroy();
-        storageAccessUnregister();
-        if(pinCodeLayout != null)
-        {
-            getWindowManager().removeView(pinCodeLayout);
-        }
     }
 
     protected void requestStorageAccess()


### PR DESCRIPTION
* Before, opening a second app and returning results in two PIN screens
appearing, followed by a crash
* Now, opening a second app and returning should display one PIN screen