### PR TITLE
alternate local.properties

### DIFF
--- a/backbone/build.gradle
+++ b/backbone/build.gradle
@@ -39,7 +39,7 @@ android {
 
 // Reading in data from local.properties is used here to grab key/value pairs used below in ext
 // Originally, it read the local.properties, but this file should never be committed to vcs,
-// so it created an odd scenario, so allow for a file named local.properties.bintray instead
+// So check if it exists first, because some projects may not care about it
 Properties properties = new Properties()
 if (project.rootProject.file('local.properties').exists()) {
     properties.load(project.rootProject.file('local.properties').newDataInputStream())

--- a/backbone/build.gradle
+++ b/backbone/build.gradle
@@ -38,9 +38,14 @@ android {
 }
 
 // Reading in data from local.properties is used here to grab key/value pairs used below in ext
-// Any local.properties file will be used, even ones entitled local.properties.some_other_qualifier
+// Originally, it read the local.properties, but this file should never be committed to vcs,
+// so it created an odd scenario, so allow for a file named local.properties.bintray instead
 Properties properties = new Properties()
-properties.load(project.rootProject.file('local.properties').newDataInputStream())
+if (project.rootProject.file('local.properties').exists()) {
+    properties.load(project.rootProject.file('local.properties').newDataInputStream())
+} else if (project.rootProject.file('local.properties.bintray').exists()) {
+    properties.load(project.rootProject.file('local.properties.bintray').newDataInputStream())
+}
 
 ext {
     bintrayRepo = 'ResearchStack'

--- a/backbone/build.gradle
+++ b/backbone/build.gradle
@@ -43,8 +43,6 @@ android {
 Properties properties = new Properties()
 if (project.rootProject.file('local.properties').exists()) {
     properties.load(project.rootProject.file('local.properties').newDataInputStream())
-} else if (project.rootProject.file('local.properties.bintray').exists()) {
-    properties.load(project.rootProject.file('local.properties.bintray').newDataInputStream())
 }
 
 ext {


### PR DESCRIPTION
added alternative way to get bintray key/value pairs that doesn't involve a file you are supposed to ignore