### PR TITLE
lint_errors

### DIFF
--- a/backbone/build.gradle
+++ b/backbone/build.gradle
@@ -34,6 +34,11 @@ android {
         exclude 'META-INF/NOTICE.txt'
     }
 
+    // TODO: remove all warnings to backbone, and then remove this
+    lintOptions {
+        abortOnError false
+    }
+
     resourcePrefix 'rsb_'
 }
 

--- a/skin/build.gradle
+++ b/skin/build.gradle
@@ -38,6 +38,11 @@ android {
         exclude 'META-INF/NOTICE.txt'
     }
 
+    // TODO: remove all warnings to skin, and then remove this
+    lintOptions {
+        abortOnError false
+    }
+
     resourcePrefix 'rss_'
 }
 


### PR DESCRIPTION
remove lint abort on error for now, until we get all the warnings gone from this library