### PR TITLE
Update Sqlcipher to 3.5.4 to enable Android N support

### DIFF
--- a/backbone/build.gradle
+++ b/backbone/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'com.neenbedankt.android-apt'
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 
-version = '1.1.1'
+version = '1.1.2'
 
 android {
     compileSdkVersion 23

--- a/backbone/build.gradle
+++ b/backbone/build.gradle
@@ -82,7 +82,7 @@ dependencies {
     compile 'com.scottyab:aes-crypto:0.0.3'
     compile 'co.touchlab.squeaky:squeaky-query:0.4.0.0'
     apt 'co.touchlab.squeaky:squeaky-processor:0.4.0.0'
-    compile 'net.zetetic:android-database-sqlcipher:3.3.1-2@aar'
+    compile 'net.zetetic:android-database-sqlcipher:3.5.4@aar'
     testCompile 'junit:junit:4.12'
     testCompile 'org.robolectric:robolectric:3.0'
     testCompile 'org.mockito:mockito-core:1.10.19'

--- a/skin/build.gradle
+++ b/skin/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'me.tatarka.retrolambda'
 apply plugin: 'com.neenbedankt.android-apt'
 apply plugin: 'com.jfrog.bintray'
 
-version = '1.1.1'
+version = '1.1.2'
 
 android {
     compileSdkVersion 23


### PR DESCRIPTION
Updates Sqlcipher to 3.5.4 to resolve issues mentioned here: https://github.com/ResearchStack/ResearchStack/issues/282 and here: https://github.com/ResearchStack/SampleApp/issues/17