### PR TITLE
Feature/update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ android:
     # The BuildTools version used by your project
     # per travis-ci issue #5036, add '-tools' to use build-tools-23.0.2
     - tools
-    - build-tools-25.0.0
+    - build-tools-25.0.2
 
     # The SDK version used to compile your project
     - android-25

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,12 +31,7 @@ before_install:
   - export JAVA8_HOME=/usr/lib/jvm/java-8-oracle
   - export JAVA_HOME=$JAVA8_HOME
 
-before_script:
-  # Tests crash if a local.properties file isn't present; this file is not kept
-  # under version control. Create an empty local.properties for testing.
-  - touch local.properties
-
-script: ./gradlew test
+script: ./gradlew build
 
 # Uncomment line below to add post-test scripts.
 # after_script:

--- a/backbone/build.gradle
+++ b/backbone/build.gradle
@@ -35,11 +35,6 @@ android {
         exclude 'META-INF/NOTICE.txt'
     }
 
-    // TODO: remove all warnings to backbone, and then remove this
-    lintOptions {
-        abortOnError false
-    }
-
     resourcePrefix 'rsb_'
 }
 
@@ -65,7 +60,7 @@ ext {
     gitUrl = 'https://github.com/ResearchStack/ResearchStack.git'
 
     libraryVersion = version
-24
+
     // This grabs the key/value pairs from local.properties and assigns them to variables that
     // can be used in gradle, and specifically, the mavenInstaller below
     userOrgName = 'researchstack'

--- a/backbone/build.gradle
+++ b/backbone/build.gradle
@@ -9,7 +9,7 @@ version = '2.0.0-SNAPSHOT'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.0"
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         minSdkVersion 16
@@ -60,7 +60,7 @@ ext {
     gitUrl = 'https://github.com/ResearchStack/ResearchStack.git'
 
     libraryVersion = version
-
+24
     // This grabs the key/value pairs from local.properties and assigns them to variables that
     // can be used in gradle, and specifically, the mavenInstaller below
     userOrgName = 'researchstack'
@@ -80,16 +80,17 @@ dependencies {
     compile 'com.android.support:appcompat-v7:25.1.0'
     compile 'com.android.support:cardview-v7:25.1.0'
     compile 'com.android.support:preference-v14:25.1.0'
+    compile 'com.android.support:support-annotations:25.1.0'
     compile 'com.android.support:design:25.1.0'
 
     compile 'com.google.code.gson:gson:2.4'
-    compile 'io.reactivex:rxjava:1.1.3'
-    compile 'io.reactivex:rxandroid:1.1.0'
+    compile 'io.reactivex:rxjava:1.2.5'
+    compile 'io.reactivex:rxandroid:1.2.1'
 
-    compile 'com.jakewharton.rxbinding:rxbinding:0.2.0'
-    compile 'com.jakewharton.rxbinding:rxbinding-support-v4:0.2.0'
-    compile 'com.jakewharton.rxbinding:rxbinding-appcompat-v7:0.2.0'
-    compile 'com.jakewharton.rxbinding:rxbinding-design:0.2.0'
+    compile 'com.jakewharton.rxbinding:rxbinding:0.4.0'
+    compile 'com.jakewharton.rxbinding:rxbinding-support-v4:0.4.0'
+    compile 'com.jakewharton.rxbinding:rxbinding-appcompat-v7:0.4.0'
+    compile 'com.jakewharton.rxbinding:rxbinding-design:0.4.0'
 
     // Used to display UploadData and study data in various chart formats
     compile 'com.github.PhilJay:MPAndroidChart:v2.2.3'

--- a/backbone/build.gradle
+++ b/backbone/build.gradle
@@ -159,6 +159,9 @@ if (project.hasProperty("android")) { // Android libraries
     task javadoc(type: Javadoc) {
         failOnError false
         source = android.sourceSets.main.java.srcDirs
+        // Exclude generated files
+        exclude '**/BuildConfig.java'
+        exclude '**/R.java'
     }
 
     afterEvaluate {

--- a/backbone/build.gradle
+++ b/backbone/build.gradle
@@ -35,6 +35,10 @@ android {
         exclude 'META-INF/NOTICE.txt'
     }
 
+    lintOptions {
+        abortOnError false
+    }
+
     resourcePrefix 'rsb_'
 }
 

--- a/backbone/build.gradle
+++ b/backbone/build.gradle
@@ -35,6 +35,11 @@ android {
         exclude 'META-INF/NOTICE.txt'
     }
 
+    // TODO: remove all warnings to backbone, and then remove this
+    lintOptions {
+        abortOnError false
+    }
+
     resourcePrefix 'rsb_'
 }
 
@@ -98,6 +103,7 @@ dependencies {
     compile 'com.scottyab:aes-crypto:0.0.3'
     compile 'co.touchlab.squeaky:squeaky-query:0.4.0.0'
     apt 'co.touchlab.squeaky:squeaky-processor:0.4.0.0'
+
     compile 'net.zetetic:android-database-sqlcipher:3.5.4@aar'
     testCompile 'junit:junit:4.12'
     testCompile 'org.robolectric:robolectric:3.0'

--- a/backbone/src/main/java/org/researchstack/backbone/DataProvider.java
+++ b/backbone/src/main/java/org/researchstack/backbone/DataProvider.java
@@ -2,7 +2,6 @@ package org.researchstack.backbone;
 
 import android.app.Application;
 import android.content.Context;
-import android.support.annotation.AnyThread;
 
 import org.researchstack.backbone.model.ConsentSignature;
 import org.researchstack.backbone.model.ConsentSignatureBody;

--- a/backbone/src/main/java/org/researchstack/backbone/DataProvider.java
+++ b/backbone/src/main/java/org/researchstack/backbone/DataProvider.java
@@ -2,6 +2,7 @@ package org.researchstack.backbone;
 
 import android.app.Application;
 import android.content.Context;
+import android.support.annotation.AnyThread;
 
 import org.researchstack.backbone.model.ConsentSignature;
 import org.researchstack.backbone.model.ConsentSignatureBody;

--- a/build.gradle
+++ b/build.gradle
@@ -13,8 +13,12 @@ buildscript {
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
         classpath 'me.tatarka:gradle-retrolambda:3.2.3'
+        // workaround lint bug concerning lombok (used by retrolambda)
+        classpath 'me.tatarka.retrolambda.projectlombok:lombok.ast:0.2.3.a2'
         classpath "com.neenbedankt.gradle.plugins:android-apt:1.4"
 
+        // Exclude the lombok version that the android plugin depends on.
+        configurations.classpath.exclude group: 'com.android.tools.external.lombok'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
     dependencies {
         // change this to 1.5.x if you're not on Android Studio 2.0.0 beta
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
         classpath 'me.tatarka:gradle-retrolambda:3.2.3'

--- a/skin/build.gradle
+++ b/skin/build.gradle
@@ -38,6 +38,10 @@ android {
         exclude 'META-INF/NOTICE.txt'
     }
 
+    lintOptions {
+        abortOnError false
+    }
+
     resourcePrefix 'rss_'
 }
 

--- a/skin/build.gradle
+++ b/skin/build.gradle
@@ -38,11 +38,6 @@ android {
         exclude 'META-INF/NOTICE.txt'
     }
 
-    // TODO: remove all warnings to skin, and then remove this
-    lintOptions {
-        abortOnError false
-    }
-
     resourcePrefix 'rss_'
 }
 

--- a/skin/build.gradle
+++ b/skin/build.gradle
@@ -9,7 +9,7 @@ version = '2.0.0-SNAPSHOT'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.0"
+    buildToolsVersion "25.0.2"
 
     lintOptions {
         warning "InvalidPackage"
@@ -37,7 +37,12 @@ android {
         exclude 'META-INF/LICENSE.txt'
         exclude 'META-INF/NOTICE.txt'
     }
-    
+
+    // TODO: remove all warnings to skin, and then remove this
+    lintOptions {
+        abortOnError false
+    }
+
     resourcePrefix 'rss_'
 }
 
@@ -86,6 +91,7 @@ dependencies {
     compile 'com.squareup.retrofit2:adapter-rxjava:2.0.0-beta3'
     compile 'com.squareup.okhttp3:logging-interceptor:3.0.0-RC1'
 
+    compile 'com.android.support:support-annotations:25.1.0'
 }
 
 // this could be a script, since it is used in two places


### PR DESCRIPTION
- Performs `./gradlew build` instead of `./gradlew test`, so errors which show up in build but not test will be caught here, instead of packages which pull this repo in as a submodule
- Reduce noise from tools breaking on retrolambda/lombok
- Reduce javadoc noise on `:backbone`, unsure why same code does not work for `:skin` and why `:skin` is not including generated classes the same as backbone
- Updates dependencies. Currently, BridgeAndroidSDK and mPower will substitute in newer versions via dependency resolution, but depending on which project is the root, the result can vary greatly. Updated to be closer in version. This was especially annoying when Studio would pick compile against one version, but its tooling would use another version (not sure why or how this happens)