### PR TITLE
Update retrofit

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,6 @@ com.jakewharton.rxbinding:rxbinding
 - RxJava binding APIs for Android UI widgets from the platform and support libraries. Provides helper methods that wrap API methods and returns Rx Observables
 
 <b>
-com.squareup.okhttp3:logging-interceptor
 com.squareup.retrofit2:adapter-rxjava
 com.squareup.retrofit2:converter-gson
 com.squareup.retrofit2:retrofit

--- a/skin/build.gradle
+++ b/skin/build.gradle
@@ -80,17 +80,21 @@ ext {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar', '*.so'])
-    compile 'com.cronutils:cron-utils:3.1.2'
     compile project(':backbone')
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.robolectric:robolectric:3.0'
-    testCompile 'org.mockito:mockito-core:1.10.19'
-    compile 'com.squareup.retrofit2:retrofit:2.0.0-beta3'
-    compile 'com.squareup.retrofit2:converter-gson:2.0.0-beta3'
-    compile 'com.squareup.retrofit2:adapter-rxjava:2.0.0-beta3'
-    compile 'com.squareup.okhttp3:logging-interceptor:3.0.0-RC1'
-
     compile 'com.android.support:support-annotations:25.1.0'
+
+    //TODO: update this dependency
+    compile 'com.cronutils:cron-utils:3.1.2'
+
+    // retrofit and its addons for rxjava and gson
+    compile 'com.squareup.retrofit2:retrofit:2.1.0'
+    compile 'com.squareup.retrofit2:adapter-rxjava:2.1.0'
+    compile 'com.squareup.retrofit2:converter-gson:2.1.0'
+
+    testCompile 'junit:junit:4.12'
+    testCompile 'org.mockito:mockito-core:1.10.19'
+    testCompile 'org.robolectric:robolectric:3.0'
+
 }
 
 // this could be a script, since it is used in two places


### PR DESCRIPTION
Fixes sporadic annoying AndroidStudio behavior.

For some reason, AndroidStudio gets out of sync with bytecode/source version with transitive dependency resolution. Sometimes, the tooling checks against retrofit2 2.0.0-beta3, which results in erroneous error messages, like not being able to resolve `isSuccessful.isSuccessful()` 