### PR TITLE
Unit Test bug

### DIFF
--- a/skin/src/main/java/org/researchstack/skin/ui/fragment/ActivitiesFragment.java
+++ b/skin/src/main/java/org/researchstack/skin/ui/fragment/ActivitiesFragment.java
@@ -238,7 +238,7 @@ public abstract class ActivitiesFragment extends Fragment implements StorageAcce
      * @return a list of section groups and section headers
      */
     public List<Object> processResults(SchedulesAndTasksModel model) {
-        if (model == null) {
+        if (model == null || model.schedules == null) {
             return Lists.newArrayList();
         }
         List<Object> tasks = new ArrayList<>();


### PR DESCRIPTION
It was assumed that if schedules was null, an empty list would be returned.  However, that didn't exists so I added it.