### PR TITLE
Capitalize Next button

### DIFF
--- a/backbone/src/main/res/values/strings.xml
+++ b/backbone/src/main/res/values/strings.xml
@@ -100,7 +100,7 @@
     <string name="rsb_get_started">Get Started</string>
     <string name="rsb_done">Done</string>
     <string name="rsb_step_skip">Skip</string>
-    <string name="rsb_next">next</string>
+    <string name="rsb_next">Next</string>
     <string name="rsb_what_to_expect">What to Expect</string>
     <string name="rsb_name">Name</string>
     <string name="rsb_name_placeholder">Enter full name</string>


### PR DESCRIPTION
This was never caught because android buttons usually do all caps, but if you disable that, the all lowercase is inappropriate per UI guidelines.