### PR TITLE
Feature/AA-140

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/model/survey/factory/SurveyFactory.java
+++ b/backbone/src/main/java/org/researchstack/backbone/model/survey/factory/SurveyFactory.java
@@ -58,6 +58,7 @@ import org.researchstack.backbone.step.NavigationExpectedAnswerQuestionStep;
 import org.researchstack.backbone.step.NavigationSubtaskStep;
 import org.researchstack.backbone.step.active.ActiveStep;
 import org.researchstack.backbone.task.SmartSurveyTask;
+import org.researchstack.backbone.ui.ActiveTaskActivity;
 import org.researchstack.backbone.ui.step.layout.PasscodeCreationStepLayout;
 
 import java.util.ArrayList;
@@ -906,6 +907,7 @@ public class SurveyFactory {
     }
 
     public void fillActiveStep(ActiveStep step, ActiveStepSurveyItem item) {
+        step.setActivityClazz(ActiveTaskActivity.class);
         if (item.title != null) {
             step.setTitle(item.title);
         }

--- a/backbone/src/main/java/org/researchstack/backbone/step/AudioTooLoudStep.java
+++ b/backbone/src/main/java/org/researchstack/backbone/step/AudioTooLoudStep.java
@@ -1,11 +1,9 @@
 package org.researchstack.backbone.step;
 
-import org.researchstack.backbone.result.AudioResult;
-import org.researchstack.backbone.result.StepResult;
 import org.researchstack.backbone.result.TaskResult;
+import org.researchstack.backbone.step.active.recorder.AudioRecorder;
 import org.researchstack.backbone.task.NavigableOrderedTask;
 import org.researchstack.backbone.utils.LogExt;
-import org.researchstack.backbone.utils.StepResultHelper;
 
 import java.util.List;
 
@@ -45,25 +43,11 @@ public class AudioTooLoudStep extends InstructionStep implements NavigableOrdere
 
     @Override
     public boolean shouldSkipStep(TaskResult result, List<TaskResult> additionalTaskResults) {
-        // Check if audio is too loud by using a rolling average in AudioResult object
-        StepResult stepResult = StepResultHelper.findStepResult(result, audioStepResultIdentifier);
-        if (stepResult != null && !stepResult.getResults().keySet().isEmpty()) {
-            for (Object key : stepResult.getResults().keySet()) {
-                Object value = stepResult.getResults().get(key);
-                if (value instanceof AudioResult) {
-                    AudioResult audioResult = (AudioResult)value;
-                    boolean isResultTooLoud = audioResult.getRollingAverageOfVolume() > loudnessThreshold;
-
-                    LogExt.i(getClass(), "Audio is " + (isResultTooLoud ? "" : "not") +
-                            " too loud with value of " + audioResult.getRollingAverageOfVolume());
-
-                    isSkippingStep = !isResultTooLoud;
-                    return isSkippingStep;
-                }
-            }
-        }
-        isSkippingStep = true;
-        return true;
+        boolean isResultTooLoud = AudioRecorder.getLastTotalSampleAvg() > loudnessThreshold;
+        LogExt.i(getClass(), "Audio is " + (isResultTooLoud ? "" : "not") +
+                " too loud with value of " + AudioRecorder.getLastTotalSampleAvg());
+        isSkippingStep = !isResultTooLoud;
+        return !isResultTooLoud;
     }
 
     @Override

--- a/backbone/src/main/java/org/researchstack/backbone/step/active/ActiveStep.java
+++ b/backbone/src/main/java/org/researchstack/backbone/step/active/ActiveStep.java
@@ -2,10 +2,12 @@ package org.researchstack.backbone.step.active;
 
 import org.researchstack.backbone.step.Step;
 import org.researchstack.backbone.step.active.recorder.RecorderConfig;
+import org.researchstack.backbone.ui.ActiveTaskActivity;
 import org.researchstack.backbone.ui.step.layout.ActiveStepLayout;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * Created by TheMDP on 2/4/17.
@@ -187,10 +189,20 @@ public class ActiveStep extends Step {
     private Map<String, String> spokenInstructionMap;
 
     /**
+     * The recording UUID is a unique identifier used by the RecorderService
+     */
+    private UUID recordingUuid;
+
+    /**
      * This can be increased to allow the ending spoken instruction to
      * not get cut off if it is too long
      */
-    private int estimateTimeInMsToSpeakEndInstruction = 2000;  // 2 seconds
+    private int estimateTimeInMsToSpeakEndInstruction = 1000;  // 1 second delay after finishing
+
+    /**
+     * The class of the activity that will run this step
+     */
+    private Class<? extends ActiveTaskActivity> activityClazz = ActiveTaskActivity.class;
 
     /* Default constructor needed for serialization/deserialization of object */
     ActiveStep() {
@@ -200,12 +212,14 @@ public class ActiveStep extends Step {
     public ActiveStep(String identifier) {
         super(identifier);
         setOptional(false);
+        recordingUuid = UUID.randomUUID();
     }
 
     public ActiveStep(String identifier, String title, String detailText) {
         super(identifier, title);
         setText(detailText);
         setOptional(false);
+        recordingUuid = UUID.randomUUID();
     }
 
     @Override
@@ -362,5 +376,21 @@ public class ActiveStep extends Step {
 
     public void setEstimateTimeInMsToSpeakEndInstruction(int estimateTimeInMsToSpeakEndInstruction) {
         this.estimateTimeInMsToSpeakEndInstruction = estimateTimeInMsToSpeakEndInstruction;
+    }
+
+    public UUID getRecordingUuid() {
+        return recordingUuid;
+    }
+
+    public void setRecordingUuid(UUID recordingUuid) {
+        this.recordingUuid = recordingUuid;
+    }
+
+    public Class<? extends ActiveTaskActivity> getActivityClazz() {
+        return activityClazz;
+    }
+
+    public void setActivityClazz(Class<? extends ActiveTaskActivity> activityClazz) {
+        this.activityClazz = activityClazz;
     }
 }

--- a/backbone/src/main/java/org/researchstack/backbone/step/active/ActiveTaskAndResultListener.java
+++ b/backbone/src/main/java/org/researchstack/backbone/step/active/ActiveTaskAndResultListener.java
@@ -1,0 +1,30 @@
+/*
+ *    Copyright 2018 Sage Bionetworks
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+package org.researchstack.backbone.step.active;
+
+import org.researchstack.backbone.result.TaskResult;
+import org.researchstack.backbone.task.Task;
+
+/**
+ * Created by TheMDP on 1/12/18.
+ */
+
+public interface ActiveTaskAndResultListener {
+    Task activeTaskActivityGetTask();
+    TaskResult activeTaskActivityResult();
+}

--- a/backbone/src/main/java/org/researchstack/backbone/step/active/CountdownStep.java
+++ b/backbone/src/main/java/org/researchstack/backbone/step/active/CountdownStep.java
@@ -29,6 +29,7 @@ public class CountdownStep extends ActiveStep {
         setShouldStartTimerAutomatically(true);
         setShouldShowDefaultTimer(false);
         setShouldContinueOnFinish(true);
+        setEstimateTimeInMsToSpeakEndInstruction(0); // do not wait to proceed
     }
 
     @Override

--- a/backbone/src/main/java/org/researchstack/backbone/step/active/RecorderService.java
+++ b/backbone/src/main/java/org/researchstack/backbone/step/active/RecorderService.java
@@ -33,7 +33,6 @@ import android.os.Handler;
 import android.os.IBinder;
 import android.os.Vibrator;
 import android.speech.tts.TextToSpeech;
-import android.support.annotation.DrawableRes;
 import android.support.annotation.Nullable;
 import android.support.annotation.RequiresPermission;
 import android.support.v4.app.NotificationCompat;
@@ -50,7 +49,6 @@ import org.researchstack.backbone.step.active.recorder.Recorder;
 import org.researchstack.backbone.step.active.recorder.RecorderConfig;
 import org.researchstack.backbone.step.active.recorder.RecorderListener;
 import org.researchstack.backbone.task.Task;
-import org.researchstack.backbone.ui.ActiveTaskActivity;
 import org.researchstack.backbone.ui.ViewTaskActivity;
 import org.researchstack.backbone.utils.LogExt;
 
@@ -83,9 +81,12 @@ public class RecorderService extends Service implements RecorderListener, TextTo
 
     private static final String INTENT_KEY_OUTPUT_DIRECTORY     = "RecorderOutputDirectory";
 
-    public static String BROADCAST_RECORDER_COMPLETE        = "RecorderService_RecordingComplete";
-    public static String BROADCAST_RECORDER_METRONOME       = "RecorderService_MetronomeBroadcast";
-    public static String BROADCAST_RECORDER_METRONOME_CTR   = "RecorderService_MetronomeCtr";
+    public static String ACTION_BROADCAST_RECORDER_COMPLETE     = "RecorderService_RecordingComplete";
+    public static String ACTION_BROADCAST_RECORDER_METRONOME    = "RecorderService_MetronomeBroadcast";
+    public static String ACTION_BROADCAST_RECORDER_SPOKEN_TEXT  = "RecorderService_SpokenTextBroadcast";
+
+    public static String BROADCAST_RECORDER_METRONOME_CTR       = "RecorderService_MetronomeCtr";
+    public static String BROADCAST_RECORDER_SPOKEN_TEXT         = "RecorderService_SpokenText";
 
     /**
      * @param appContext
@@ -426,7 +427,7 @@ public class RecorderService extends Service implements RecorderListener, TextTo
 
     private void sendRecorderErrorBroadcast(String errorMessage) {
         LogExt.d(RecorderService.class, "sendRecorderErrorBroadcast()");
-        Intent broadcastIntent = new Intent(BROADCAST_RECORDER_COMPLETE);
+        Intent broadcastIntent = new Intent(ACTION_BROADCAST_RECORDER_COMPLETE);
         ResultHolder resultHolder = new ResultHolder();
         resultHolder.setErrorMessage(errorMessage);
         resultHolder.setStartTime(startTime);
@@ -436,7 +437,7 @@ public class RecorderService extends Service implements RecorderListener, TextTo
 
     private void sendRecorderCompleteBroadcast() {
         LogExt.d(RecorderService.class, "sendRecorderCompleteBroadcast()");
-        Intent broadcastIntent = new Intent(BROADCAST_RECORDER_COMPLETE);
+        Intent broadcastIntent = new Intent(ACTION_BROADCAST_RECORDER_COMPLETE);
         ResultHolder resultHolder = new ResultHolder();
         resultHolder.setResultList(resultList);
         resultHolder.setStartTime(startTime);
@@ -444,9 +445,15 @@ public class RecorderService extends Service implements RecorderListener, TextTo
         LocalBroadcastManager.getInstance(this).sendBroadcast(broadcastIntent);
     }
 
-    private void sendMetronomeBroadcast(int ctr) {
-        Intent broadcastIntent = new Intent(BROADCAST_RECORDER_METRONOME);
+    protected void sendMetronomeBroadcast(int ctr) {
+        Intent broadcastIntent = new Intent(ACTION_BROADCAST_RECORDER_METRONOME);
         broadcastIntent.putExtra(BROADCAST_RECORDER_METRONOME_CTR, ctr);
+        LocalBroadcastManager.getInstance(this).sendBroadcast(broadcastIntent);
+    }
+
+    protected void sendSpokenTextBroadcast(String spokenText) {
+        Intent broadcastIntent = new Intent(ACTION_BROADCAST_RECORDER_SPOKEN_TEXT);
+        broadcastIntent.putExtra(BROADCAST_RECORDER_SPOKEN_TEXT, spokenText);
         LocalBroadcastManager.getInstance(this).sendBroadcast(broadcastIntent);
     }
 
@@ -572,6 +579,7 @@ public class RecorderService extends Service implements RecorderListener, TextTo
         } else {
             ttsUnder20(text);
         }
+        sendSpokenTextBroadcast(text);
     }
 
     @SuppressWarnings("deprecation")

--- a/backbone/src/main/java/org/researchstack/backbone/step/active/RecorderService.java
+++ b/backbone/src/main/java/org/researchstack/backbone/step/active/RecorderService.java
@@ -88,6 +88,11 @@ public class RecorderService extends Service implements RecorderListener, TextTo
     public static String BROADCAST_RECORDER_METRONOME_CTR       = "RecorderService_MetronomeCtr";
     public static String BROADCAST_RECORDER_SPOKEN_TEXT         = "RecorderService_SpokenText";
 
+    // keys associated with spokenInstructions json recorder configs
+    public static final String TEXT_TO_SPEECH_END_KEY = "end";
+    public static final String TEXT_TO_SPEECH_COUNTDOWN_KEY = "countdown";
+    public static final String TEXT_TO_SPEECH_METRONOME_KEY = "metronome";
+
     /**
      * @param appContext
      * @return the saved result list, if this active step has already completed recording
@@ -300,22 +305,19 @@ public class RecorderService extends Service implements RecorderListener, TextTo
     }
 
     protected void startSpeechToTextMap() {
-        String endKey = "end";
-        String countdownKey = "countdown";
-        String metronomeKey = "metronome";
 
         Map<String, String> speechToTextMap = activeStep.getSpokenInstructionMap();
         if (speechToTextMap != null) {
             for (String speechKey : speechToTextMap.keySet()) {
 
                 // Check for special case "end" key that speaks after the step duration
-                if (endKey.equals(speechKey)) {
+                if (TEXT_TO_SPEECH_END_KEY.equals(speechKey)) {
                     final String endSpeechText = speechToTextMap.get(speechKey);
                     mainHandler.postDelayed(() -> speakTextAndUpdateNotification(endSpeechText),
                             activeStep.getStepDuration() * 1000L);
 
                     // Check for special case "countdown" key that speaks a verbal seconds countdown
-                } else if (countdownKey.equals(speechKey)) {
+                } else if (TEXT_TO_SPEECH_COUNTDOWN_KEY.equals(speechKey)) {
                     try {
                         int countdownTime = Integer.parseInt(speechToTextMap.get(speechKey));
                         for (int i = countdownTime; i > 0; i--) {
@@ -327,7 +329,7 @@ public class RecorderService extends Service implements RecorderListener, TextTo
                         LogExt.e(RecorderService.class, e.getLocalizedMessage());
                     }
                     // All other cases will speak the text at the seconds time of the speechKey
-                } else if (metronomeKey.equals(speechKey)) {
+                } else if (TEXT_TO_SPEECH_METRONOME_KEY.equals(speechKey)) {
                     try {
                         double metronomeIntervalInSec =
                                 Double.parseDouble(speechToTextMap.get(speechKey));

--- a/backbone/src/main/java/org/researchstack/backbone/step/active/RecorderService.java
+++ b/backbone/src/main/java/org/researchstack/backbone/step/active/RecorderService.java
@@ -1,0 +1,307 @@
+/*
+ *    Copyright 2018 Sage Bionetworks
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+package org.researchstack.backbone.step.active;
+
+import android.app.Notification;
+import android.app.PendingIntent;
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.IBinder;
+import android.support.annotation.DrawableRes;
+import android.support.v4.app.NotificationCompat;
+import android.support.v4.content.LocalBroadcastManager;
+import android.util.Log;
+
+import org.researchstack.backbone.R;
+import org.researchstack.backbone.result.FileResult;
+import org.researchstack.backbone.result.Result;
+import org.researchstack.backbone.step.active.recorder.Recorder;
+import org.researchstack.backbone.step.active.recorder.RecorderConfig;
+import org.researchstack.backbone.step.active.recorder.RecorderListener;
+import org.researchstack.backbone.ui.ActiveTaskActivity;
+
+import java.io.File;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by TheMDP on 1/10/18.
+ */
+
+public class RecorderService extends Service implements RecorderListener {
+
+    private static final String LOGGING_TAG = RecorderService.class.getSimpleName();
+
+    private static final String NOTIFICATION_CHANNEL_ID = "RecorderService_NotificationChannel";
+
+    private static final String INTENT_KEY_NOTIFICATION_ICON_RES    = "NotificationIconRes";
+    private static final String INTENT_KEY_NOTIFICATION_TITLE       = "NotificationTitle";
+    private static final String INTENT_KEY_RECORDER_CONFIG_LIST     = "RecordConfigList";
+    private static final String INTENT_KEY_ACTIVE_STEP              = "RecorderActiveStep";
+    private static final String INTENT_KEY_OUTPUT_DIRECTORY         = "RecorderOutputDirectory";
+
+    private static final String STATUS_EXTRA = "status";
+
+    public static final String BROADCAST_RECORDER_ERROR                = "RecorderService_Error";
+    public static final String BROADCAST_RECORDER_ERROR_MESSAGE_KEY    = "ErrorMessage";
+
+    public static String BROADCAST_RECORDER_COMPLETE            = "RecorderService_RecordingComplete";
+    public static String BROADCAST_RECORDER_COMPLETE_RESULTS    = "RecorderService_RecordingResults";
+
+    public static FileResultList getResultList(Intent intent) {
+        if (intent == null || intent.getExtras() == null ||
+                !intent.getExtras().containsKey(BROADCAST_RECORDER_COMPLETE_RESULTS)) {
+            return new FileResultList();
+        }
+        return (FileResultList) intent.getExtras()
+                .getSerializable(BROADCAST_RECORDER_COMPLETE_RESULTS);
+    }
+
+    /**
+     * @param appContext needed to create the intent
+     * @param activeStep currently being run, must contain a valid stepDuration
+     * @param recorderConfigList of the recorders to create and run
+     * @param outputDirectory for the recorders
+     * @return the intent to launch via "appContext.startService()"
+     */
+    public static Intent startService(Context appContext,
+                                      ActiveStep activeStep,
+                                      List<RecorderConfig> recorderConfigList,
+                                      File outputDirectory) {
+
+        Intent intent = new Intent(appContext, RecorderService.class);
+        Bundle extras = new Bundle();
+
+        RecorderConfigList configList = new RecorderConfigList();
+        configList.setConfigList(recorderConfigList);
+        extras.putSerializable(INTENT_KEY_RECORDER_CONFIG_LIST, configList);
+
+        extras.putSerializable(INTENT_KEY_ACTIVE_STEP, activeStep);
+        extras.putSerializable(INTENT_KEY_OUTPUT_DIRECTORY, outputDirectory);
+
+        intent.putExtras(extras);
+        return intent;
+    }
+
+    private Handler mainHandler;
+    private List<Recorder> recorderList;
+    private List<FileResult> resultList;
+
+    private Notification foregroundNotification;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        Log.v(LOGGING_TAG, "onCreate");
+        // no-op, wait for onStartCommand
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        Log.v(LOGGING_TAG, "onStartCommand");
+
+        mainHandler = new Handler();
+
+        RecorderConfigList configList = new RecorderConfigList();
+        File outputDir = null;
+        ActiveStep activeStep = null;
+        if (intent != null && intent.getExtras() != null) {
+            Bundle bundle = intent.getExtras();
+            if (bundle.containsKey(INTENT_KEY_RECORDER_CONFIG_LIST)) {
+                configList = (RecorderConfigList)bundle
+                        .getSerializable(INTENT_KEY_RECORDER_CONFIG_LIST);
+            }
+            if (bundle.containsKey(INTENT_KEY_ACTIVE_STEP)) {
+                activeStep = (ActiveStep)bundle.getSerializable(INTENT_KEY_ACTIVE_STEP);
+            }
+            if (bundle.containsKey(INTENT_KEY_OUTPUT_DIRECTORY)) {
+                outputDir = (File)bundle.getSerializable(INTENT_KEY_OUTPUT_DIRECTORY);
+            }
+        }
+
+        boolean isConfigListValid = configList != null &&
+                configList.getConfigList() != null &&
+                !configList.getConfigList().isEmpty();
+
+        if (activeStep != null && activeStep.getStepDuration() > 0 && isConfigListValid) {
+
+            String notificationTitle = getString(R.string.rsb_recorder_notification_title);
+            // This will ensure that this service is never destroyed
+            showForegroundNotification(R.drawable.rsb_ic_recorder_notification, notificationTitle);
+
+            // Start the recording process
+            for (RecorderConfig recorderConfig : configList.getConfigList()) {
+                Recorder recorder = recorderConfig.recorderForStep(activeStep, outputDir);
+                // recorder can be null if it requires custom setup,
+                // but that will require a custom RecorderService to handle
+                if (recorder != null) {
+                    recorder.setRecorderListener(this);
+                    recorderList.add(recorder);
+                    recorder.start(getApplicationContext());
+                }
+            }
+
+            // Now allow the recorder to record for as long as the active step requires
+            mainHandler.postDelayed(() -> {
+                onRecorderDurationFinished();
+            }, activeStep.getStepDuration() * 1000L);
+
+        } else {
+            String errorMessage = "Cannot record because ActiveStep is not valid";
+            if (!isConfigListValid) {
+                errorMessage = "Recorder config list is not valid";
+            }
+            Log.e(LOGGING_TAG, errorMessage);
+            sendRecorderErrorBroadcast(errorMessage);
+            stopSelf();
+        }
+
+        return START_NOT_STICKY;
+    }
+
+    public boolean isServiceRecording() {
+        return recorderList != null && !recorderList.isEmpty();
+    }
+
+    /**
+     * This would never be called under normal operation while the recorders are running
+     * It will only be called when the user chooses to end the task and discard the results
+     * or in special very rare cases like user shut their phone off, serious memory issues, etc
+     * It should be treated like a recorder canceled scenario
+     */
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        Log.d(LOGGING_TAG, "onDestroyed service is stopping");
+
+        mainHandler.removeCallbacksAndMessages(null);
+        sendRecorderErrorBroadcast("RecorderService destroyed while recording");
+        if (isServiceRecording()) {
+            for (Recorder recorder : recorderList) {
+                recorder.cancel();
+            }
+        }
+        recorderList.clear();
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;  // no need, pass everything through LocalBroadcastManager and Intents
+    }
+
+    private void showForegroundNotification(@DrawableRes int smallIcon, String notificationMessage) {
+        Intent notificationIntent = new Intent(this, ActiveTaskActivity.class);
+        notificationIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, notificationIntent, 0);
+
+        String msg = getString(R.string.rsb_recording);
+
+        NotificationCompat.Builder notificationBuilder =
+                new NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
+                        .setSmallIcon(smallIcon)
+                        .setContentTitle(notificationMessage)
+                        .setContentText(msg)
+                        .setContentIntent(pendingIntent);
+
+        foregroundNotification = notificationBuilder.build();
+        startForeground(1, foregroundNotification);
+    }
+
+    private void sendRecorderErrorBroadcast(String errorMessage) {
+        Intent broadcastIntent = new Intent(BROADCAST_RECORDER_ERROR);
+        Bundle intentData = new Bundle();
+        intentData.putString(BROADCAST_RECORDER_ERROR_MESSAGE_KEY, errorMessage);
+        broadcastIntent.putExtras(intentData);
+        LocalBroadcastManager.getInstance(this).sendBroadcast(broadcastIntent);
+    }
+
+    private void sendRecorderCompleteBroadcast() {
+        Intent broadcastIntent = new Intent(BROADCAST_RECORDER_COMPLETE);
+        Bundle intentData = new Bundle();
+        broadcastIntent.putExtras(intentData);
+        LocalBroadcastManager.getInstance(this).sendBroadcast(broadcastIntent);
+    }
+
+    private void onRecorderDurationFinished() {
+
+    }
+
+    /**
+     * RecorderListener callback
+     * @param recorder        The generating recorder object.
+     * @param result          The generated result.
+     */
+    @Override
+    public void onComplete(Recorder recorder, Result result) {
+
+    }
+
+    /**
+     * RecorderListener callback
+     * @param recorder        The generating recorder object.
+     * @param error           The error that occurred.
+     */
+    @Override
+    public void onFail(Recorder recorder, Throwable error) {
+
+    }
+
+    /**
+     * Holder class for encapsulation serializable list data sent through intents
+     */
+    public static class FileResultList implements Serializable {
+        private List<FileResult> resultList;
+
+        public FileResultList() {
+            super();
+            resultList = new ArrayList<>();
+        }
+
+        public List<FileResult> getResultList() {
+            return resultList;
+        }
+
+        public void setResultList(List<FileResult> resultList) {
+            this.resultList = resultList;
+        }
+    }
+
+    /**
+     * Holder class for encapsulation serializable list data sent through intents
+     */
+    protected static class RecorderConfigList implements Serializable {
+        private List<RecorderConfig> configList;
+
+        public RecorderConfigList() {
+            super();
+            configList = new ArrayList<>();
+        }
+
+        public List<RecorderConfig> getConfigList() {
+            return configList;
+        }
+
+        public void setConfigList(List<RecorderConfig> configList) {
+            this.configList = configList;
+        }
+    }
+}

--- a/backbone/src/main/java/org/researchstack/backbone/step/active/RecorderService.java
+++ b/backbone/src/main/java/org/researchstack/backbone/step/active/RecorderService.java
@@ -544,7 +544,7 @@ public class RecorderService extends Service implements RecorderListener, TextTo
 
     @Nullable
     @Override
-    public Context onBroadcastContextRequested() {
+    public Context getBroadcastContext() {
         return this;
     }
 

--- a/backbone/src/main/java/org/researchstack/backbone/step/active/recorder/AudioRecorder.java
+++ b/backbone/src/main/java/org/researchstack/backbone/step/active/recorder/AudioRecorder.java
@@ -2,19 +2,24 @@ package org.researchstack.backbone.step.active.recorder;
 
 import android.Manifest;
 import android.content.Context;
+import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.media.MediaRecorder;
 import android.os.Build;
+import android.os.Bundle;
 import android.os.Handler;
+import android.support.v4.content.LocalBroadcastManager;
 import android.webkit.MimeTypeMap;
 
 import org.researchstack.backbone.R;
 import org.researchstack.backbone.result.AudioResult;
+import org.researchstack.backbone.result.FileResult;
 import org.researchstack.backbone.step.Step;
 import org.researchstack.backbone.utils.LogExt;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Date;
 
 /**
@@ -35,7 +40,8 @@ public class AudioRecorder extends Recorder {
      */
     private static final int AVERAGE_MAX_VOLUME_DURATION = 100;
 
-    private AudioRecorderListener audioRecorderListener;
+    public static final String BROADCAST_SAMPLE_ACTION  = "AudioRecorder_BroadcastSample";
+    private static final String BROADCAST_SAMPLE_KEY    = "BroadcastSample";
 
     /**
      * Used to check amplitude of the sample at a desired frequency
@@ -62,6 +68,18 @@ public class AudioRecorder extends Recorder {
     private AudioRecorderSettings settings;
     private MediaRecorder mediaRecorder;
     private long startTime;
+
+    private static double sLastSampleAvg;
+    /**
+     * @return The last audio sample recorder, the total average volume from 0 - 1
+     *         The is most useful for determining if an area is too loud or noisy
+     */
+    public static double getLastTotalSampleAvg() {
+       return sLastSampleAvg;
+    }
+    protected void setLastTotalSampleAvg(double totalAvg) {
+        sLastSampleAvg = totalAvg;
+    }
 
     AudioRecorder(AudioRecorderSettings settings,
                   String identifier,
@@ -157,11 +175,11 @@ public class AudioRecorder extends Recorder {
                     // Compute the new rolling average
                     addSampleToRollingAverages(currentIntensity);
 
-                    if (audioRecorderListener != null && msBetweenCallbacks > 0) {
+                    if (msBetweenCallbacks > 0) {
                         long now = System.currentTimeMillis();
                         if ((now - timeOfLastCallback) > msBetweenCallbacks) {
                             int averageSample = (int) (sampleSumSinceLastCallback / samplesSinceLastCallback);
-                            audioRecorderListener.onAudioSampleRecorded(averageSample, MAX_VOLUME);
+                            sendAverageSampleBroadcast(averageSample);
                             refreshCallbackVariables();
                         }
                     }
@@ -171,6 +189,31 @@ public class AudioRecorder extends Recorder {
         };
         // Smallest possible delay to get the most information about the audio recording
         mainHandler.postDelayed(sampleMonitorRunnable, AVERAGE_MAX_VOLUME_DURATION);
+    }
+
+    private void sendAverageSampleBroadcast(int averageSample) {
+        AverageSampleHolder sampleHolder = new AverageSampleHolder();
+        sampleHolder.averageSampleVolume = averageSample;
+        sampleHolder.maxVolume = MAX_VOLUME;
+        Bundle bundle = new Bundle();
+        bundle.putSerializable(BROADCAST_SAMPLE_KEY, sampleHolder);
+        Intent intent = new Intent(BROADCAST_SAMPLE_ACTION);
+        intent.putExtras(bundle);
+        sendBroadcast(intent);
+    }
+
+    /**
+     * @param intent must have action of BROADCAST_SAMPLE_ACTION
+     * @return the AverageSampleHolder contained in the broadcast
+     */
+    public static AverageSampleHolder getAverageSample(Intent intent) {
+        if (intent.getAction() == null ||
+                !intent.getAction().equals(BROADCAST_SAMPLE_ACTION) ||
+                intent.getExtras() == null ||
+                !intent.getExtras().containsKey(BROADCAST_SAMPLE_KEY)) {
+            return null;
+        }
+        return (AverageSampleHolder) intent.getExtras().getSerializable(BROADCAST_SAMPLE_KEY);
     }
 
     private void stopSampleMonitoring() {
@@ -209,15 +252,16 @@ public class AudioRecorder extends Recorder {
         String filepath = fullFilePath();
         File file = new File(filepath);
         String mimeType = getMimeType(filepath);
-        AudioResult audioResult = new AudioResult(fileResultIdentifier(), file, mimeType);
-        audioResult.setStartDate(new Date(startTime));
-        audioResult.setEndDate(new Date());
+        FileResult fileResult = new FileResult(fileResultIdentifier(), file, mimeType);
+        fileResult.setStartDate(new Date(startTime));
+        fileResult.setEndDate(new Date());
 
-        double totalAvgIntensityFrom0To1 = ((double)totalRollingAvg / (double)totalRollingAvgSampleCount) / (double)MAX_VOLUME;
-        audioResult.setRollingAverageOfVolume(totalAvgIntensityFrom0To1);
+        double totalAvgIntensityFrom0To1 = ((double)totalRollingAvg /
+                (double)totalRollingAvgSampleCount) / (double)MAX_VOLUME;
+        setLastTotalSampleAvg(totalAvgIntensityFrom0To1);
 
         // Return the result to the recorder listener
-        onRecorderCompleted(audioResult);
+        onRecorderCompleted(fileResult);
     }
 
     @Override
@@ -225,7 +269,7 @@ public class AudioRecorder extends Recorder {
         stopSampleMonitoring();
 
         if (mediaRecorder == null) {
-            throw new IllegalStateException("Cannot cancel media recorder since it has not been started");
+            return; // no reason to cancel anything, since the mediaRecorder never started
         }
 
         stopAndReleaseMediaRecorder();
@@ -266,23 +310,36 @@ public class AudioRecorder extends Recorder {
     }
 
     /**
-     * @param audioRecorderListener the listener to recieve onAudioSampleRecorded calls
      * @param timeBetweenListenerCalls Duration cannot currently be less than 100 milliseconds
      *                                 the duration in milliseconds that will be in between calls to onAudioSampleRecorded
      */
-    public void setAudioRecorderListener(
-            AudioRecorderListener audioRecorderListener,
-            long timeBetweenListenerCalls)
+    public void setAudioRecorderBroadcastInterval(long timeBetweenListenerCalls)
     {
-        this.audioRecorderListener = audioRecorderListener;
         this.msBetweenCallbacks = timeBetweenListenerCalls;
     }
 
-    public interface AudioRecorderListener {
-        /**
-         * @param averageSampleVolume the current sample's volume
-         * @param maxVolume the max volume that the sampleVolume can be
-         */
-        void onAudioSampleRecorded(int averageSampleVolume, int maxVolume);
+    public static class AverageSampleHolder implements Serializable {
+        private int averageSampleVolume;
+        private int maxVolume;
+
+        public AverageSampleHolder() {
+            super();
+        }
+
+        public int getAverageSampleVolume() {
+            return averageSampleVolume;
+        }
+
+        public void setAverageSampleVolume(int averageSampleVolume) {
+            this.averageSampleVolume = averageSampleVolume;
+        }
+
+        public int getMaxVolume() {
+            return maxVolume;
+        }
+
+        public void setMaxVolume(int maxVolume) {
+            this.maxVolume = maxVolume;
+        }
     }
 }

--- a/backbone/src/main/java/org/researchstack/backbone/step/active/recorder/AudioRecorder.java
+++ b/backbone/src/main/java/org/researchstack/backbone/step/active/recorder/AudioRecorder.java
@@ -77,7 +77,7 @@ public class AudioRecorder extends Recorder {
     public static double getLastTotalSampleAvg() {
        return sLastSampleAvg;
     }
-    protected void setLastTotalSampleAvg(double totalAvg) {
+    public static void setLastTotalSampleAvg(double totalAvg) {
         sLastSampleAvg = totalAvg;
     }
 

--- a/backbone/src/main/java/org/researchstack/backbone/step/active/recorder/AudioRecorderConfig.java
+++ b/backbone/src/main/java/org/researchstack/backbone/step/active/recorder/AudioRecorderConfig.java
@@ -22,6 +22,9 @@ public class AudioRecorderConfig extends RecorderConfig {
 
     private AudioRecorderSettings settings;
 
+    private static final long DEFAULT_TIME_BETWEEN_BROADCASTS = 180;
+    private long timeBetweenAverageSampleBroadcasts = DEFAULT_TIME_BETWEEN_BROADCASTS;
+
     /** Default constructor used for serialization/deserialization */
     AudioRecorderConfig() {
         super();
@@ -34,7 +37,9 @@ public class AudioRecorderConfig extends RecorderConfig {
 
     @Override
     public Recorder recorderForStep(Step step, File outputDirectory) {
-        return new AudioRecorder(settings, identifier, step, outputDirectory);
+        AudioRecorder audioRecorder = new AudioRecorder(settings, identifier, step, outputDirectory);
+        audioRecorder.setAudioRecorderBroadcastInterval(timeBetweenAverageSampleBroadcasts);
+        return audioRecorder;
     }
 
     public AudioRecorderSettings getSettings() {
@@ -43,5 +48,13 @@ public class AudioRecorderConfig extends RecorderConfig {
 
     public void setSettings(AudioRecorderSettings settings) {
         this.settings = settings;
+    }
+
+    public long getTimeBetweenAverageSampleBroadcasts() {
+        return timeBetweenAverageSampleBroadcasts;
+    }
+
+    public void setTimeBetweenAverageSampleBroadcasts(long timeBetweenAverageSampleBroadcasts) {
+        this.timeBetweenAverageSampleBroadcasts = timeBetweenAverageSampleBroadcasts;
     }
 }

--- a/backbone/src/main/java/org/researchstack/backbone/step/active/recorder/PedometerRecorder.java
+++ b/backbone/src/main/java/org/researchstack/backbone/step/active/recorder/PedometerRecorder.java
@@ -1,9 +1,11 @@
 package org.researchstack.backbone.step.active.recorder;
 
 import android.content.Context;
+import android.content.Intent;
 import android.hardware.Sensor;
 import android.hardware.SensorEvent;
 import android.os.Build;
+import android.os.Bundle;
 import android.support.annotation.MainThread;
 
 import com.google.gson.JsonObject;
@@ -14,6 +16,7 @@ import org.researchstack.backbone.model.UserHealth;
 import org.researchstack.backbone.step.Step;
 
 import java.io.File;
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
 
@@ -27,10 +30,13 @@ public class PedometerRecorder extends SensorRecorder
     public static final String TIMESTAMP_KEY   = "timestamp";
     public static final String END_DATE        = "endDate";
     public static final String NUMBER_OF_STEPS = "numberOfSteps";
-    public static final String DISTANCE        = "distance";
+    public static final String DISTANCE        = "totalDistance";
+
+    public static final String BROADCAST_PEDOMETER_UPDATE_ACTION  = "LocationRecorder_BroadcastPedometerUpdate";
+    private static final String BROADCAST_PEDOMETER_UPDATE_KEY    = "PedometerUpdate";
 
     /**
-     * This used to compute the distance the user has traveled while recording the pedometer
+     * This used to compute the totalDistance the user has traveled while recording the pedometer
      * The default value is about half a meter, it will only be used when a user's height is unavailable
      */
     public static final float DEFAULT_METERS_PER_STRIDE = 0.6f; // in meters
@@ -47,8 +53,6 @@ public class PedometerRecorder extends SensorRecorder
 
     private int stepCounter;
     private JsonObject jsonObject;
-
-    private PedometerListener pedometerListener;
 
     PedometerRecorder(String identifier, Step step, File outputDirectory) {
         super(MANUAL_JSON_FREQUENCY, identifier, step, outputDirectory);
@@ -122,10 +126,7 @@ public class PedometerRecorder extends SensorRecorder
         float distance = strideLength * stepCounter;
         jsonObject.addProperty(DISTANCE, distance);
         super.writeJsonObjectToFile(jsonObject);
-
-        if (pedometerListener != null) {
-            pedometerListener.onStepTaken(stepCounter, distance);
-        }
+        sendPedometerUpdateBroadcast(stepCounter, distance);
     }
 
     @Override
@@ -145,19 +146,50 @@ public class PedometerRecorder extends SensorRecorder
         // NO-OP
     }
 
-    public PedometerListener getPedometerListener() {
-        return pedometerListener;
+    protected void sendPedometerUpdateBroadcast(int stepCount, float totalDistance) {
+        PedometerUpdateHolder dataHolder = new PedometerUpdateHolder();
+        dataHolder.setStepCount(stepCount);
+        dataHolder.setTotalDistance(totalDistance);
+        Bundle bundle = new Bundle();
+        bundle.putSerializable(BROADCAST_PEDOMETER_UPDATE_KEY, dataHolder);
+        Intent intent = new Intent(BROADCAST_PEDOMETER_UPDATE_ACTION);
+        intent.putExtras(bundle);
+        sendBroadcast(intent);
     }
 
-    public void setPedometerListener(PedometerListener pedometerListener) {
-        this.pedometerListener = pedometerListener;
+    /**
+     * @param intent must have action of BROADCAST_PEDOMETER_UPDATE_ACTION
+     * @return the PedometerUpdateHolder contained in the broadcast
+     */
+    public static PedometerUpdateHolder getPedometerUpdateHolder(Intent intent) {
+        if (intent.getAction() == null ||
+                !intent.getAction().equals(BROADCAST_PEDOMETER_UPDATE_ACTION) ||
+                intent.getExtras() == null ||
+                intent.getExtras().containsKey(BROADCAST_PEDOMETER_UPDATE_KEY)) {
+            return null;
+        }
+        return (PedometerUpdateHolder) intent.getExtras()
+                .getSerializable(BROADCAST_PEDOMETER_UPDATE_KEY);
     }
 
-    public interface PedometerListener {
-        /**
-         * @param stepCount the current step count
-         * @param distance the total distance covered so far, in meters
-         */
-        void onStepTaken(int stepCount, float distance);
+    public static class PedometerUpdateHolder implements Serializable {
+        private int stepCount;
+        private float totalDistance;
+
+        public int getStepCount() {
+            return stepCount;
+        }
+
+        public void setStepCount(int stepCount) {
+            this.stepCount = stepCount;
+        }
+
+        public float getTotalDistance() {
+            return totalDistance;
+        }
+
+        public void setTotalDistance(float totalDistance) {
+            this.totalDistance = totalDistance;
+        }
     }
 }

--- a/backbone/src/main/java/org/researchstack/backbone/step/active/recorder/Recorder.java
+++ b/backbone/src/main/java/org/researchstack/backbone/step/active/recorder/Recorder.java
@@ -1,7 +1,9 @@
 package org.researchstack.backbone.step.active.recorder;
 
 import android.content.Context;
+import android.content.Intent;
 import android.support.annotation.MainThread;
+import android.support.v4.content.LocalBroadcastManager;
 
 import org.researchstack.backbone.result.Result;
 import org.researchstack.backbone.step.Step;
@@ -187,6 +189,15 @@ public abstract class Recorder {
     protected void onRecorderFailed(Throwable throwable) {
         if (recorderListener != null) {
             recorderListener.onFail(this, throwable);
+        }
+    }
+
+    protected void sendBroadcast(Intent intent) {
+        if (recorderListener != null) {
+            Context context = recorderListener.onBroadcastContextRequested();
+            if (context != null) {
+                LocalBroadcastManager.getInstance(context).sendBroadcast(intent);
+            }
         }
     }
 

--- a/backbone/src/main/java/org/researchstack/backbone/step/active/recorder/Recorder.java
+++ b/backbone/src/main/java/org/researchstack/backbone/step/active/recorder/Recorder.java
@@ -9,7 +9,6 @@ import org.researchstack.backbone.result.Result;
 import org.researchstack.backbone.step.Step;
 
 import java.io.File;
-import java.io.Serializable;
 import java.util.UUID;
 
 /**
@@ -194,7 +193,7 @@ public abstract class Recorder {
 
     protected void sendBroadcast(Intent intent) {
         if (recorderListener != null) {
-            Context context = recorderListener.onBroadcastContextRequested();
+            Context context = recorderListener.getBroadcastContext();
             if (context != null) {
                 LocalBroadcastManager.getInstance(context).sendBroadcast(intent);
             }

--- a/backbone/src/main/java/org/researchstack/backbone/step/active/recorder/RecorderListener.java
+++ b/backbone/src/main/java/org/researchstack/backbone/step/active/recorder/RecorderListener.java
@@ -37,5 +37,6 @@ public interface RecorderListener {
     /**
      * @return a valid Context for the recorder to broadcast status, null if not available
      */
-    @Nullable Context onBroadcastContextRequested();
+    @Nullable
+    Context getBroadcastContext();
 }

--- a/backbone/src/main/java/org/researchstack/backbone/step/active/recorder/RecorderListener.java
+++ b/backbone/src/main/java/org/researchstack/backbone/step/active/recorder/RecorderListener.java
@@ -1,5 +1,8 @@
 package org.researchstack.backbone.step.active.recorder;
 
+import android.content.Context;
+import android.support.annotation.Nullable;
+
 import org.researchstack.backbone.result.Result;
 import org.researchstack.backbone.step.active.recorder.Recorder;
 
@@ -30,4 +33,9 @@ public interface RecorderListener {
      * @param error           The error that occurred.
      */
     void onFail(Recorder recorder, Throwable error);
+
+    /**
+     * @return a valid Context for the recorder to broadcast status, null if not available
+     */
+    @Nullable Context onBroadcastContextRequested();
 }

--- a/backbone/src/main/java/org/researchstack/backbone/task/factory/AudioTaskFactory.java
+++ b/backbone/src/main/java/org/researchstack/backbone/task/factory/AudioTaskFactory.java
@@ -153,7 +153,7 @@ public class AudioTaskFactory {
             // can correctly direct the user based on the results of the audio recording
             step.setLoudnessThreshold(LOUDNESS_THRESHOLD);
             step.setAudioStepResultIdentifier(CountdownStepIdentifier);
-            step.setNextStepIdentifier(CountdownStepIdentifier);
+            step.setNextStepIdentifier(Instruction1StepIdentifier);
 
             stepList.add(step);
         }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/ViewTaskActivity.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/ViewTaskActivity.java
@@ -79,6 +79,10 @@ public class ViewTaskActivity extends PinCodeActivity implements StepCallbacks
                 taskResult = new TaskResult(task.getIdentifier());
             }
 
+            if (getIntent().hasExtra(EXTRA_STEP)) {
+                currentStep = (Step)getIntent().getSerializableExtra(EXTRA_STEP);
+            }
+
             taskResult.setStartDate(new Date());
         }
         else
@@ -180,14 +184,19 @@ public class ViewTaskActivity extends PinCodeActivity implements StepCallbacks
 
         // Return the Class & constructor
         StepLayout stepLayout = StepLayoutHelper.createLayoutFromStep(step, this);
+        setupStepLayoutBeforeInitializeIsCalled(stepLayout);
         stepLayout.initialize(step, result);
-        stepLayout.setCallbacks(this);
 
         if (stepLayout instanceof ResultListener) {
             ((ResultListener)stepLayout).taskResult(this, taskResult);
         }
 
         return stepLayout;
+    }
+
+    protected void setupStepLayoutBeforeInitializeIsCalled(StepLayout stepLayout) {
+        // can be implemented by sub-classes to set up the step layout before it's initialized
+        stepLayout.setCallbacks(this);
     }
 
     protected void saveAndFinish()

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ActiveStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ActiveStepLayout.java
@@ -272,7 +272,7 @@ public class ActiveStepLayout extends FixedSubmitBarLayout
                 if (intent == null || intent.getAction() == null) {
                     return;
                 }
-                if (RecorderService.BROADCAST_RECORDER_COMPLETE.equals(intent.getAction())) {
+                if (RecorderService.ACTION_BROADCAST_RECORDER_COMPLETE.equals(intent.getAction())) {
                     LogExt.d(ActiveStepLayout.class, "RecorderService complete broadcast received");
                     RecorderService.ResultHolder resultHolder =
                             RecorderService.consumeSavedResultList(appContext, activeStep);
@@ -283,10 +283,22 @@ public class ActiveStepLayout extends FixedSubmitBarLayout
                     } else {
                         processRecorderServiceResults(resultHolder, false);
                     }
+                } else if (RecorderService.ACTION_BROADCAST_RECORDER_METRONOME.equals(intent.getAction())) {
+                    if (intent.hasExtra(RecorderService.BROADCAST_RECORDER_METRONOME_CTR)) {
+                        recorderServiceMetronomeAction(intent.getIntExtra(
+                                RecorderService.BROADCAST_RECORDER_METRONOME_CTR, 0));
+                    }
+                } else if (RecorderService.ACTION_BROADCAST_RECORDER_SPOKEN_TEXT.equals(intent.getAction())) {
+                    if (intent.hasExtra(RecorderService.BROADCAST_RECORDER_SPOKEN_TEXT)) {
+                        recorderServiceSpokeText(intent.getStringExtra(
+                                RecorderService.BROADCAST_RECORDER_SPOKEN_TEXT));
+                    }
                 }
             }
         };
-        IntentFilter intentFilter = new IntentFilter(RecorderService.BROADCAST_RECORDER_COMPLETE);
+        IntentFilter intentFilter = new IntentFilter(RecorderService.ACTION_BROADCAST_RECORDER_COMPLETE);
+        intentFilter.addAction(RecorderService.ACTION_BROADCAST_RECORDER_METRONOME);
+        intentFilter.addAction(RecorderService.ACTION_BROADCAST_RECORDER_SPOKEN_TEXT);
         LocalBroadcastManager.getInstance(appContext)
                 .registerReceiver(recorderServiceReceiver, intentFilter);
     }
@@ -582,5 +594,13 @@ public class ActiveStepLayout extends FixedSubmitBarLayout
             Log.e(getClass().getCanonicalName(), "Failed to initialize TTS with error code " + i);
             tts = null;
         }
+    }
+
+    protected void recorderServiceMetronomeAction(int metronomeCtr) {
+        // Can be implemented by sub-class to do UI events on metronome sound
+    }
+
+    protected void recorderServiceSpokeText(String spokenText) {
+        // Can be implemented by sub-class to also show text in the UI
     }
 }

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ActiveStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/ActiveStepLayout.java
@@ -2,8 +2,10 @@ package org.researchstack.backbone.ui.step.layout;
 
 import android.Manifest;
 import android.annotation.TargetApi;
+import android.content.BroadcastReceiver;
 import android.content.Context;
-import android.content.DialogInterface;
+import android.content.Intent;
+import android.content.IntentFilter;
 import android.media.AudioManager;
 import android.media.ToneGenerator;
 import android.os.Build;
@@ -11,6 +13,7 @@ import android.os.Handler;
 import android.os.Vibrator;
 import android.speech.tts.TextToSpeech;
 import android.support.annotation.RequiresPermission;
+import android.support.v4.content.LocalBroadcastManager;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.View;
@@ -20,25 +23,24 @@ import android.widget.ProgressBar;
 import android.widget.TextView;
 
 import org.researchstack.backbone.R;
+import org.researchstack.backbone.result.FileResult;
 import org.researchstack.backbone.result.Result;
 import org.researchstack.backbone.result.StepResult;
 import org.researchstack.backbone.step.Step;
 import org.researchstack.backbone.step.active.ActiveStep;
-import org.researchstack.backbone.step.active.recorder.Recorder;
-import org.researchstack.backbone.step.active.recorder.RecorderConfig;
-import org.researchstack.backbone.step.active.recorder.RecorderListener;
+import org.researchstack.backbone.step.active.ActiveTaskAndResultListener;
+import org.researchstack.backbone.step.active.RecorderService;
 import org.researchstack.backbone.ui.callbacks.StepCallbacks;
 import org.researchstack.backbone.ui.views.FixedSubmitBarLayout;
 import org.researchstack.backbone.utils.LogExt;
 import org.researchstack.backbone.utils.ResUtils;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 
-import rx.functions.Action1;
+import static org.researchstack.backbone.step.active.RecorderService.DEFAULT_VIBRATION_AND_SOUND_DURATION;
 
 /**
  * Created by TheMDP on 2/4/17.
@@ -71,9 +73,7 @@ import rx.functions.Action1;
  */
 
 public class ActiveStepLayout extends FixedSubmitBarLayout
-        implements StepLayout, RecorderListener, TextToSpeech.OnInitListener {
-
-    private static final int DEFAULT_VIBRATION_AND_SOUND_DURATION = 500; // in milliseconds
+        implements StepLayout, TextToSpeech.OnInitListener {
 
     /**
      * When this is true, files will be saved externally so you can read them
@@ -87,29 +87,34 @@ public class ActiveStepLayout extends FixedSubmitBarLayout
 
     protected StepCallbacks callbacks;
 
-    protected List<Recorder> recorderList;
+    private BroadcastReceiver recorderServiceReceiver;
 
     protected StepResult<Result> stepResult;
-
     protected Handler  mainHandler;
     protected Runnable animationRunnable;
     protected long startTime;
+
     protected int  secondsLeft;
-    protected long continueOnFinishDelay = 0;
 
     protected ActiveStep activeStep;
-
     protected LinearLayout activeStepLayout;
+    protected boolean isDetached;
+
     public LinearLayout getActiveStepLayout() {
         return activeStepLayout;
     }
-
     protected TextView titleTextview;
     protected TextView textTextview;
     protected TextView timerTextview;
     protected ProgressBar progressBar;
     protected ProgressBar progressBarHorizontal;
+
     protected ImageView imageView;
+
+    protected ActiveTaskAndResultListener taskAndResultListener;
+    public void setTaskAndResultListener(ActiveTaskAndResultListener listener) {
+        taskAndResultListener = listener;
+    }
 
     public ActiveStepLayout(Context context) {
         super(context);
@@ -148,9 +153,66 @@ public class ActiveStepLayout extends FixedSubmitBarLayout
             tts = new TextToSpeech(getContext(), this);
         }
 
-        if (activeStep.getShouldStartTimerAutomatically()) {
-            start();
+        if (!checkForAndLoadExistingState()) {
+            if (activeStep.getShouldStartTimerAutomatically()) {
+                start();
+            }
         }
+    }
+
+    /**
+     * This is called when the activity containing this active step layout
+     * has previously moved to onPause and is coming back to the foreground with onResume
+     * This will only happen when the user actually leaves the app, or shuts off the screen, then returns
+     */
+    public void resumeActiveStepLayout() {
+        if (isDetached) {  // we can only resume if this view were previously detached
+            checkForAndLoadExistingState();
+        }
+    }
+
+    /**
+     * This is called when the activity containing this active step layout
+     * has moved to onPause and we should stop responding to broadcasts and anything else UI related
+     */
+    public void pauseActiveStepLayout() {
+        LogExt.d(ActiveStepLayout.class, "pauseActiveStepLayout()");
+        removeUiRelatedItemsAndCallbacks();
+    }
+
+    protected void removeUiRelatedItemsAndCallbacks() {
+        LogExt.d(ActiveStepLayout.class, "removeUiRelatedItemsAndCallbacks()");
+        isDetached = true;
+        mainHandler.removeCallbacksAndMessages(null);
+        if (tts != null) {
+            tts.shutdown();
+            tts = null;
+        }
+        unregisterRecorderBroadcastReceivers();
+    }
+
+    protected boolean checkForAndLoadExistingState() {
+        isDetached = false;
+        Context appContext = getContext().getApplicationContext();
+
+        // Check if this view is being re-created after it was destroyed while recording finished
+        RecorderService.ResultHolder resultHolder =
+                RecorderService.consumeSavedResultList(appContext, activeStep);
+        if (resultHolder != null) {
+            // This view was destroyed while we were running the recorders in
+            // the background in the RecorderService, and now we are being re-created
+            // after the recorder has finished
+            stepLayoutWasResumedInFinishedState(resultHolder);
+            return true;
+        }
+
+        // Check if this view was destroyed and re-created while the recorder was still running
+        Long recorderStartTime = RecorderService.getStartTime(appContext, activeStep);
+        if (recorderStartTime != null) {
+            stepLayoutWasResumedInRecordingState(recorderStartTime);
+            return true;
+        }
+        return false;
     }
 
     protected void setupSubmitBar() {
@@ -160,12 +222,7 @@ public class ActiveStepLayout extends FixedSubmitBarLayout
 
         if (activeStep.isOptional()) {
             submitBar.getNegativeActionView().setVisibility(View.VISIBLE);
-            submitBar.setNegativeAction(new Action1() {
-                @Override
-                public void call(Object o) {
-                    skip();
-                }
-            });
+            submitBar.setNegativeAction(o -> skip());
         } else {
             submitBar.getNegativeActionView().setVisibility(View.GONE);
         }
@@ -174,18 +231,77 @@ public class ActiveStepLayout extends FixedSubmitBarLayout
             submitBar.setPositiveActionViewEnabled(false);
         } else {
             submitBar.setPositiveTitle(R.string.rsb_BUTTON_GET_STARTED);
-            submitBar.setPositiveAction(new Action1() {
-                @Override
-                public void call(Object o) {
-                    submitBar.setPositiveTitle(R.string.rsb_BUTTON_NEXT);
-                    start();
-                }
+            submitBar.setPositiveAction(o -> {
+                submitBar.setPositiveTitle(R.string.rsb_BUTTON_NEXT);
+                start();
             });
+        }
+    }
+
+    /**
+     * This method will be called when we were recording in the background with RecorderService
+     * and this step layout was destroyed and then re-created before the recording finished
+     */
+    protected void stepLayoutWasResumedInRecordingState(long recordingStartTime) {
+        LogExt.d(ActiveStepLayout.class, "stepLayoutWasResumedInRecordingState()");
+        // can be implemented by sub-class to resume it's UI
+        startTime = recordingStartTime;
+        startAnimation();
+
+        // Since we are not finished recording, we should re-register for recorder broadcasts
+        Context appContext = getContext().getApplicationContext();
+        registerRecorderBroadcastReceivers(appContext);
+    }
+
+    /**
+     * Should be implemented by sub-class to resume it's UI in the finished state
+     * This method will be called when we were recording in the background with RecorderService
+     * and this step layout was destroyed by the OS and then re-created after recording has finished
+     */
+    protected void stepLayoutWasResumedInFinishedState(RecorderService.ResultHolder resultHolder) {
+        LogExt.d(ActiveStepLayout.class, "stepLayoutWasCreatedInFinishedState()");
+        processRecorderServiceResults(resultHolder, true);
+    }
+
+    protected void registerRecorderBroadcastReceivers(Context appContext) {
+        LogExt.d(ActiveStepLayout.class, "registerRecorderBroadcastReceivers()");
+        recorderServiceReceiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                if (intent == null || intent.getAction() == null) {
+                    return;
+                }
+                if (RecorderService.BROADCAST_RECORDER_COMPLETE.equals(intent.getAction())) {
+                    LogExt.d(ActiveStepLayout.class, "RecorderService complete broadcast received");
+                    RecorderService.ResultHolder resultHolder =
+                            RecorderService.consumeSavedResultList(appContext, activeStep);
+                    if (resultHolder == null) {
+                        showOkAlertDialog("Critical error, no recorder results", (dialogInterface, i) -> {
+                            callbacks.onSaveStep(StepCallbacks.ACTION_END, activeStep, null);
+                        });
+                    } else {
+                        processRecorderServiceResults(resultHolder, false);
+                    }
+                }
+            }
+        };
+        IntentFilter intentFilter = new IntentFilter(RecorderService.BROADCAST_RECORDER_COMPLETE);
+        LocalBroadcastManager.getInstance(appContext)
+                .registerReceiver(recorderServiceReceiver, intentFilter);
+    }
+
+    protected void unregisterRecorderBroadcastReceivers() {
+        LogExt.d(ActiveStepLayout.class, "unregisterRecorderBroadcastReceivers()");
+        // Remove the recorder receiver, we will check if it completed when this view is re-created
+        if (recorderServiceReceiver != null) {
+            Context appContext = getContext().getApplicationContext();
+            LocalBroadcastManager.getInstance(appContext).unregisterReceiver(recorderServiceReceiver);
         }
     }
 
     @RequiresPermission(value = Manifest.permission.VIBRATE, conditional = true)
     public void start() {
+        LogExt.d(ActiveStepLayout.class, "start()");
         if (activeStep.startsFinished()) {
             return;
         }
@@ -199,30 +315,54 @@ public class ActiveStepLayout extends FixedSubmitBarLayout
         }
 
         if (activeStep.getStepDuration() > 0) {
+            startTime = System.currentTimeMillis();
             startAnimation();
         }
 
-        recorderList = new ArrayList<>();
-        File outputDir = getOutputDirectory(getContext());
-
-        if (activeStep.getRecorderConfigurationList() != null) {
-            for (RecorderConfig config : getRecorderConfigurationList()) {
-                Recorder recorder = config.recorderForStep(activeStep, outputDir);
-                // recorder can be null if it requires custom setup
-                if (recorder == null) {
-                    recorder = createCustomRecorder(config);
-                }
-                if (recorder != null) {
-                    recorder.setRecorderListener(this);
-                    recorderList.add(recorder);
-                    recorder.start(getContext());
-                }
-            }
-        }
+        startBackgroundRecorderService();
     }
 
-    public Recorder createCustomRecorder(RecorderConfig config) {
-        return null;  // to be overridden by subclass
+    protected void startBackgroundRecorderService() {
+        LogExt.d(ActiveStepLayout.class, "startBackgroundRecorderService()");
+        Context appContext = getContext().getApplicationContext();
+        if (taskAndResultListener == null) {
+            throw new IllegalStateException("taskAndResultListener cant be null +" +
+                    "this should be set through the ActiveTaskActivity");
+        }
+        RecorderService.startService(
+                appContext, getOutputDirectory(appContext), activeStep,
+                taskAndResultListener.activeTaskActivityGetTask(),
+                taskAndResultListener.activeTaskActivityResult());
+        registerRecorderBroadcastReceivers(appContext);
+    }
+
+    protected void stopRecordingService() {
+        LogExt.d(ActiveStepLayout.class, "stopRecordingService()");
+        getContext().stopService(new Intent(getContext(), RecorderService.class));
+    }
+
+    protected void processRecorderServiceResults(
+            final RecorderService.ResultHolder resultHolder, boolean delayOperation) {
+
+        long delay = delayOperation ? 100 : 0;
+        // We need to delay the callback.onSaveStep() to proceed to the next step slightly,
+        // this gives the activity time to finish setting up this StepLayout before moving to the next
+        mainHandler.postDelayed(() -> {
+            if (resultHolder.getErrorMessage() != null) {
+                LogExt.d(ActiveStepLayout.class, "RecorderService complete error message received");
+                showOkAlertDialog(resultHolder.getErrorMessage(), (dialogInterface, i) -> {
+                    callbacks.onSaveStep(StepCallbacks.ACTION_END, activeStep, null);
+                });
+            } else {
+                LogExt.d(ActiveStepLayout.class, "RecorderService complete success");
+                List<FileResult> recorderResults = resultHolder.getResultList();
+                for (Result result : recorderResults) {
+                    stepResult.setResultForIdentifier(result.getIdentifier(), result);
+                }
+                stop();
+                stepResultFinished();
+            }
+        }, delay);
     }
 
     /**
@@ -237,33 +377,9 @@ public class ActiveStepLayout extends FixedSubmitBarLayout
         return outputDir;
     }
 
-    public List<RecorderConfig> getRecorderConfigurationList() {
-        if (activeStep == null) {
-            return new ArrayList<>();
-        }
-        return activeStep.getRecorderConfigurationList();
-    }
-
     @RequiresPermission(value = Manifest.permission.VIBRATE, conditional = true)
     public void stop() {
-        if (activeStep.getShouldVibrateOnFinish()) {
-            vibrate();
-        }
-
-        if (activeStep.getShouldPlaySoundOnFinish()) {
-            playSound();
-        }
-
-        if (activeStep.getFinishedSpokenInstruction() != null) {
-            speakText(activeStep.getFinishedSpokenInstruction());
-        }
-
-        boolean noRecordersActive = (recorderList == null || recorderList.isEmpty());
-
-        for (Recorder recorder : recorderList) {
-            recorder.stop();
-        }
-
+        LogExt.d(ActiveStepLayout.class, "stop()");
         mainHandler.removeCallbacksAndMessages(null);
         if (!activeStep.getShouldContinueOnFinish()) {
             if (submitBar != null) {
@@ -271,56 +387,36 @@ public class ActiveStepLayout extends FixedSubmitBarLayout
                 submitBar.setPositiveAction(o ->
                         callbacks.onSaveStep(StepCallbacks.ACTION_NEXT, activeStep, stepResult));
             }
-        } else if (noRecordersActive) {
-            continueAfterTextDelay();
-        }
-    }
-
-    protected void continueAfterTextDelay() {
-        mainHandler.postDelayed(() -> {
-            // There will be no recorders onComplete callbacks to wait for, so just go to next activeStep
+        } else {
             callbacks.onSaveStep(StepCallbacks.ACTION_NEXT, activeStep, stepResult);
-        }, continueOnFinishDelay);
+        }
     }
 
     /**
      * A force stop should be called when this step layout is being cancelled
      */
     public void forceStop() {
-        if (recorderList != null) {
-            for (Recorder recorder : recorderList) {
-                recorder.cancel();
-            }
-        }
+        LogExt.d(ActiveStepLayout.class, "forceStop()");
+        stopRecordingService();
     }
 
     public void skip() {
-        for (Recorder recorder : recorderList) {
-            recorder.setRecorderListener(new RecorderListener() {
-                @Override
-                public void onComplete(Recorder recorder, Result result) {
-                    // no-op
-                }
-
-                @Override
-                public void onFail(Recorder recorder, Throwable error) {
-                    // no-op
-                }
-            });
-            recorder.stop();
-        }
-        recorderList.clear();
+        LogExt.d(ActiveStepLayout.class, "skip()");
+        pauseActiveStepLayout();
+        forceStop();
         callbacks.onSaveStep(StepCallbacks.ACTION_NEXT, activeStep, null);
     }
 
     protected void startAnimation() {
-        startTime = System.currentTimeMillis();
-        secondsLeft = activeStep.getStepDuration();
+        LogExt.d(ActiveStepLayout.class, "startAnimation()");
+        // Start animation may not be called when the recording starts
+        // so calculate how many seconds have gone by
+        long durationInMs = activeStep.getStepDuration() * 1000L;
+        long elapsedTimeInMs = System.currentTimeMillis() - startTime;
+        secondsLeft = (int)((durationInMs - elapsedTimeInMs) / 1000);
 
         animationRunnable = () -> {
             doUIAnimationPerSecond();
-
-            checkForSpeakInstructionMap(activeStep.getStepDuration() - secondsLeft);
 
             secondsLeft--;
 
@@ -329,49 +425,12 @@ public class ActiveStepLayout extends FixedSubmitBarLayout
             long nextSecond = startTime + timeToPast;
             long timeUntilNextSecond = nextSecond - System.currentTimeMillis();
 
-            if (secondsLeft < 0) {
-                checkForSpeakInstructionMap(activeStep.getStepDuration() - secondsLeft);
-                stop();
-            } else {
+            if (secondsLeft >= 0) {
                 mainHandler.postDelayed(animationRunnable, timeUntilNextSecond);
             }
         };
         mainHandler.removeCallbacks(animationRunnable);
         mainHandler.post(animationRunnable);
-    }
-
-    private void checkForSpeakInstructionMap(int elapsedTimeInSeconds) {
-        int secondsLeft = activeStep.getStepDuration() - elapsedTimeInSeconds;
-        // Check if we have the spoken instruction map key for this time, and speak it if we do
-        if (activeStep.getSpokenInstructionMap() != null) {
-            String elapsedSecondsKey = String.valueOf(elapsedTimeInSeconds);
-            if (activeStep.getSpokenInstructionMap().containsKey(elapsedSecondsKey)) {
-                speakText(activeStep.getSpokenInstructionMap().get(elapsedSecondsKey));
-            }
-            // Special case for allowing spoken text countdown
-            String countdownKey = "countdown";
-            if (activeStep.getSpokenInstructionMap().containsKey(countdownKey)) {
-                String countdownValStr = activeStep.getSpokenInstructionMap().get(countdownKey);
-                try {
-                    int countdownTime = Integer.parseInt(countdownValStr);
-                    if (secondsLeft <= countdownTime && secondsLeft > 0) {
-                        speakText(String.valueOf(secondsLeft));
-                    }
-                } catch (NumberFormatException e) {
-                    LogExt.e(ActiveStepLayout.class, e.getLocalizedMessage());
-                }
-            }
-            // Special case for allowing spoken text at the end instead of a seconds key
-            String endKey = "end";
-            if (secondsLeft == 0) {
-                if (activeStep.getSpokenInstructionMap().containsKey(endKey)) {
-                    // We can't speak at the "end" because it will get cut off
-                    // so delay continue on finish for an estimated amount of time
-                    continueOnFinishDelay = activeStep.getEstimateTimeInMsToSpeakEndInstruction();
-                    speakText(activeStep.getSpokenInstructionMap().get(endKey));
-                }
-            }
-        }
     }
 
     public void doUIAnimationPerSecond() {
@@ -387,24 +446,24 @@ public class ActiveStepLayout extends FixedSubmitBarLayout
     }
 
     public void setupActiveViews() {
-        titleTextview = (TextView) contentContainer.findViewById(R.id.rsb_active_step_layout_title);
+        titleTextview = contentContainer.findViewById(R.id.rsb_active_step_layout_title);
         if (titleTextview != null) {
             titleTextview.setText(activeStep.getTitle());
             titleTextview.setVisibility(activeStep.getTitle() == null ? View.GONE : View.VISIBLE);
         }
 
-        textTextview = (TextView) contentContainer.findViewById(R.id.rsb_active_step_layout_text);
+        textTextview = contentContainer.findViewById(R.id.rsb_active_step_layout_text);
         if (textTextview != null) {
             textTextview.setText(activeStep.getText());
             textTextview.setVisibility(activeStep.getText() == null ? View.GONE : View.VISIBLE);
         }
 
-        timerTextview = (TextView) contentContainer.findViewById(R.id.rsb_active_step_layout_countdown);
+        timerTextview = contentContainer.findViewById(R.id.rsb_active_step_layout_countdown);
 
-        progressBar = (ProgressBar) contentContainer.findViewById(R.id.rsb_active_step_layout_progress);
-        progressBarHorizontal = (ProgressBar) contentContainer.findViewById(R.id.rsb_active_step_layout_progress_horizontal);
+        progressBar = contentContainer.findViewById(R.id.rsb_active_step_layout_progress);
+        progressBarHorizontal = contentContainer.findViewById(R.id.rsb_active_step_layout_progress_horizontal);
 
-        imageView = (ImageView) contentContainer.findViewById(R.id.rsb_image_view);
+        imageView = contentContainer.findViewById(R.id.rsb_image_view);
         if (imageView != null) {
             if (activeStep.getImageResName() != null) {
                 int drawableInt = ResUtils.getDrawableResourceId(getContext(), activeStep.getImageResName());
@@ -417,7 +476,7 @@ public class ActiveStepLayout extends FixedSubmitBarLayout
             }
         }
 
-        activeStepLayout = (LinearLayout) contentContainer.findViewById(R.id.rsb_step_layout_active_layout);
+        activeStepLayout = contentContainer.findViewById(R.id.rsb_step_layout_active_layout);
 
         if (timerTextview != null) {
             if (activeStep.hasCountDown()) {
@@ -449,11 +508,8 @@ public class ActiveStepLayout extends FixedSubmitBarLayout
     @Override
     public void onDetachedFromWindow() {
         super.onDetachedFromWindow();
-        mainHandler.removeCallbacksAndMessages(null);
-        if (tts != null) {
-            tts.shutdown();
-            tts = null;
-        }
+        LogExt.d(ActiveStepLayout.class, "onDetachedFromWindow()");
+        removeUiRelatedItemsAndCallbacks();
     }
 
     @Override
@@ -500,39 +556,8 @@ public class ActiveStepLayout extends FixedSubmitBarLayout
         tts.speak(text, TextToSpeech.QUEUE_FLUSH, null, utteranceId);
     }
 
-    @Override
-    public void onComplete(Recorder recorder, Result result) {
-        stepResult.setResultForIdentifier(recorder.getIdentifier(), result);
-        recorderList.remove(recorder);
-        if (recorderList.isEmpty()) {
-            stepResultFinished();
-            if (activeStep.getShouldContinueOnFinish()) {
-                continueAfterTextDelay();
-            } else {
-                if (submitBar != null) {
-                    submitBar.getPositiveActionView().setEnabled(true);
-                    submitBar.setPositiveAction(o ->
-                            callbacks.onSaveStep(StepCallbacks.ACTION_NEXT, activeStep, stepResult));
-                }
-            }
-        }
-    }
-
     protected void stepResultFinished() {
         // To be implemented by sub-classes that need to save more info to step result
-    }
-
-    @Override
-    public void onFail(Recorder recorder, Throwable error) {
-        if (tts != null && tts.isSpeaking()) {
-            tts.stop();
-        }
-        super.showOkAlertDialog(error.getMessage(), new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialogInterface, int i) {
-                callbacks.onSaveStep(StepCallbacks.ACTION_END, activeStep, null);
-            }
-        });
     }
 
     // TextToSpeech initialization

--- a/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/AudioStepLayout.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ui/step/layout/AudioStepLayout.java
@@ -1,18 +1,20 @@
 package org.researchstack.backbone.ui.step.layout;
 
+import android.content.BroadcastReceiver;
 import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
 import android.support.v4.content.ContextCompat;
+import android.support.v4.content.LocalBroadcastManager;
 import android.util.AttributeSet;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
-import android.widget.TextView;
 
 import org.researchstack.backbone.R;
 import org.researchstack.backbone.step.Step;
 import org.researchstack.backbone.step.active.AudioStep;
 import org.researchstack.backbone.step.active.recorder.AudioRecorder;
-import org.researchstack.backbone.step.active.recorder.Recorder;
 import org.researchstack.backbone.ui.views.AudioGraphView;
 
 /**
@@ -22,12 +24,10 @@ import org.researchstack.backbone.ui.views.AudioGraphView;
  * It does this by taking in data from the AudioRecorder and forwarding it to an AudioGraphView
  */
 
-public class AudioStepLayout extends ActiveStepLayout implements AudioRecorder.AudioRecorderListener {
-
-    private static final long DURATION_BETWEEN_GRAPH_UPDATES = 180;
-    private long durationBetweenGraphUpdates = DURATION_BETWEEN_GRAPH_UPDATES;
+public class AudioStepLayout extends ActiveStepLayout {
 
     protected AudioStep audioStep;
+    protected BroadcastReceiver audioUpdateReciever;
 
     protected RelativeLayout audioContentLayout;
     protected AudioGraphView audioGraphView;
@@ -49,29 +49,17 @@ public class AudioStepLayout extends ActiveStepLayout implements AudioRecorder.A
     }
 
     @Override
-    public void start() {
-        super.start();
-
-        if (recorderList != null) {
-            for (Recorder recorder : recorderList) {
-                if (recorder instanceof AudioRecorder) {
-                    ((AudioRecorder)recorder).setAudioRecorderListener(this, durationBetweenGraphUpdates);
-                }
-            }
-        }
-    }
-
-    @Override
     public void setupActiveViews() {
         super.setupActiveViews();
 
-        audioContentLayout = (RelativeLayout)layoutInflater.inflate(R.layout.rsb_step_layout_audio, activeStepLayout, false);
+        audioContentLayout = (RelativeLayout)layoutInflater
+                .inflate(R.layout.rsb_step_layout_audio, activeStepLayout, false);
 
-        audioGraphView = (AudioGraphView) audioContentLayout.findViewById(R.id.rsb_step_layout_audio_graph);
+        audioGraphView = audioContentLayout.findViewById(R.id.rsb_step_layout_audio_graph);
         int primaryColor = ContextCompat.getColor(getContext(), R.color.rsb_colorPrimary);
         audioGraphView.setGraphColor(primaryColor);
 
-        timerTextview = (TextView) audioContentLayout.findViewById(R.id.rsb_step_layout_audio_countdown);
+        timerTextview = audioContentLayout.findViewById(R.id.rsb_step_layout_audio_countdown);
         timerTextview.setTextColor(primaryColor);
 
         activeStepLayout.addView(audioContentLayout, new LinearLayout.LayoutParams(
@@ -89,21 +77,38 @@ public class AudioStepLayout extends ActiveStepLayout implements AudioRecorder.A
     }
 
     @Override
-    public void onAudioSampleRecorded(int averageSampleVolume, int maxVolume) {
-        if (audioGraphView == null) {
-            // graph not ready yet
-            return;
-        }
+    protected void registerRecorderBroadcastReceivers(Context appContext) {
+        super.registerRecorderBroadcastReceivers(appContext);
+        audioUpdateReciever = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                if (intent == null || intent.getAction() == null) {
+                    return;
+                }
+                if (AudioRecorder.BROADCAST_SAMPLE_ACTION.equals(intent.getAction())) {
+                    AudioRecorder.AverageSampleHolder sampleHolder =
+                            AudioRecorder.getAverageSample(intent);
+                    if (sampleHolder != null) {
+                        if (audioGraphView == null) {
+                            // graph not ready yet
+                            return;
+                        }
 
-        audioGraphView.setMaxSampleValue(maxVolume);
-        audioGraphView.addSample(averageSampleVolume);
+                        audioGraphView.setMaxSampleValue(sampleHolder.getMaxVolume());
+                        audioGraphView.addSample(sampleHolder.getAverageSampleVolume());
+                    }
+                }
+            }
+        };
+        IntentFilter intentFilter = new IntentFilter(AudioRecorder.BROADCAST_SAMPLE_ACTION);
+        LocalBroadcastManager.getInstance(appContext)
+                .registerReceiver(audioUpdateReciever, intentFilter);
     }
 
-    public long getDurationBetweenGraphUpdates() {
-        return durationBetweenGraphUpdates;
-    }
-
-    public void setDurationBetweenGraphUpdates(long durationBetweenGraphUpdates) {
-        this.durationBetweenGraphUpdates = durationBetweenGraphUpdates;
+    @Override
+    protected void unregisterRecorderBroadcastReceivers() {
+        super.unregisterRecorderBroadcastReceivers();
+        Context appContext = getContext().getApplicationContext();
+        LocalBroadcastManager.getInstance(appContext).unregisterReceiver(audioUpdateReciever);
     }
 }

--- a/backbone/src/main/res/drawable/rsb_ic_recorder_notification.xml
+++ b/backbone/src/main/res/drawable/rsb_ic_recorder_notification.xml
@@ -1,0 +1,180 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportHeight="108"
+    android:viewportWidth="108">
+    <path
+        android:fillColor="#26A69A"
+        android:pathData="M0,0h108v108h-108z" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M9,0L9,108"
+        android:strokeColor="#33FFFFFF"
+        android:strokeWidth="0.8" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M19,0L19,108"
+        android:strokeColor="#33FFFFFF"
+        android:strokeWidth="0.8" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M29,0L29,108"
+        android:strokeColor="#33FFFFFF"
+        android:strokeWidth="0.8" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M39,0L39,108"
+        android:strokeColor="#33FFFFFF"
+        android:strokeWidth="0.8" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M49,0L49,108"
+        android:strokeColor="#33FFFFFF"
+        android:strokeWidth="0.8" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M59,0L59,108"
+        android:strokeColor="#33FFFFFF"
+        android:strokeWidth="0.8" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M69,0L69,108"
+        android:strokeColor="#33FFFFFF"
+        android:strokeWidth="0.8" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M79,0L79,108"
+        android:strokeColor="#33FFFFFF"
+        android:strokeWidth="0.8" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M89,0L89,108"
+        android:strokeColor="#33FFFFFF"
+        android:strokeWidth="0.8" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M99,0L99,108"
+        android:strokeColor="#33FFFFFF"
+        android:strokeWidth="0.8" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M0,9L108,9"
+        android:strokeColor="#33FFFFFF"
+        android:strokeWidth="0.8" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M0,19L108,19"
+        android:strokeColor="#33FFFFFF"
+        android:strokeWidth="0.8" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M0,29L108,29"
+        android:strokeColor="#33FFFFFF"
+        android:strokeWidth="0.8" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M0,39L108,39"
+        android:strokeColor="#33FFFFFF"
+        android:strokeWidth="0.8" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M0,49L108,49"
+        android:strokeColor="#33FFFFFF"
+        android:strokeWidth="0.8" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M0,59L108,59"
+        android:strokeColor="#33FFFFFF"
+        android:strokeWidth="0.8" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M0,69L108,69"
+        android:strokeColor="#33FFFFFF"
+        android:strokeWidth="0.8" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M0,79L108,79"
+        android:strokeColor="#33FFFFFF"
+        android:strokeWidth="0.8" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M0,89L108,89"
+        android:strokeColor="#33FFFFFF"
+        android:strokeWidth="0.8" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M0,99L108,99"
+        android:strokeColor="#33FFFFFF"
+        android:strokeWidth="0.8" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M19,29L89,29"
+        android:strokeColor="#33FFFFFF"
+        android:strokeWidth="0.8" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M19,39L89,39"
+        android:strokeColor="#33FFFFFF"
+        android:strokeWidth="0.8" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M19,49L89,49"
+        android:strokeColor="#33FFFFFF"
+        android:strokeWidth="0.8" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M19,59L89,59"
+        android:strokeColor="#33FFFFFF"
+        android:strokeWidth="0.8" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M19,69L89,69"
+        android:strokeColor="#33FFFFFF"
+        android:strokeWidth="0.8" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M19,79L89,79"
+        android:strokeColor="#33FFFFFF"
+        android:strokeWidth="0.8" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M29,19L29,89"
+        android:strokeColor="#33FFFFFF"
+        android:strokeWidth="0.8" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M39,19L39,89"
+        android:strokeColor="#33FFFFFF"
+        android:strokeWidth="0.8" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M49,19L49,89"
+        android:strokeColor="#33FFFFFF"
+        android:strokeWidth="0.8" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M59,19L59,89"
+        android:strokeColor="#33FFFFFF"
+        android:strokeWidth="0.8" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M69,19L69,89"
+        android:strokeColor="#33FFFFFF"
+        android:strokeWidth="0.8" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M79,19L79,89"
+        android:strokeColor="#33FFFFFF"
+        android:strokeWidth="0.8" />
+    <path
+        android:pathData="M32,64C32,64 38.39,52.99 44.13,50.95C51.37,48.37 70.14,49.57 70.14,49.57L108.26,87.69L108,109.01L75.97,107.97L32,64Z"
+        android:strokeColor="#00000000"
+        android:strokeWidth="1">
+    </path>
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M66.94,46.02L66.94,46.02C72.44,50.07 76,56.61 76,64L32,64C32,56.61 35.56,50.11 40.98,46.06L36.18,41.19C35.45,40.45 35.45,39.3 36.18,38.56C36.91,37.81 38.05,37.81 38.78,38.56L44.25,44.05C47.18,42.57 50.48,41.71 54,41.71C57.48,41.71 60.78,42.57 63.68,44.05L69.11,38.56C69.84,37.81 70.98,37.81 71.71,38.56C72.44,39.3 72.44,40.45 71.71,41.19L66.94,46.02ZM62.94,56.92C64.08,56.92 65,56.01 65,54.88C65,53.76 64.08,52.85 62.94,52.85C61.8,52.85 60.88,53.76 60.88,54.88C60.88,56.01 61.8,56.92 62.94,56.92ZM45.06,56.92C46.2,56.92 47.13,56.01 47.13,54.88C47.13,53.76 46.2,52.85 45.06,52.85C43.92,52.85 43,53.76 43,54.88C43,56.01 43.92,56.92 45.06,56.92Z"
+        android:strokeColor="#00000000"
+        android:strokeWidth="1" />
+</vector>

--- a/backbone/src/main/res/values/strings.xml
+++ b/backbone/src/main/res/values/strings.xml
@@ -144,6 +144,8 @@
     <string name="rsb_distance_meters">meters</string>
     <string name="rsb_distance_feet">feet</string>
     <string name="rsb_error_no_internet">Please check your network connection and try again.</string>
+    <string name="rsb_recording">Recording</string>
+    <string name="rsb_recorder_notification_title">Recording</string>
 
     <!-- Step Errors -->
     <string name="rsb_error_data_failed">FailedP to load encrypted data, try again!</string>

--- a/backbone/src/test/java/org/researchstack/backbone/model/taskitem/factory/TaskItemFactoryTests.java
+++ b/backbone/src/test/java/org/researchstack/backbone/model/taskitem/factory/TaskItemFactoryTests.java
@@ -4,8 +4,11 @@ import android.content.pm.PackageManager;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mock;
+import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 import org.researchstack.backbone.model.survey.factory.SurveyFactoryHelper;
 import org.researchstack.backbone.model.taskitem.TaskItem;
 import org.researchstack.backbone.step.CompletionStep;
@@ -18,6 +21,7 @@ import org.researchstack.backbone.step.active.FitnessStep;
 import org.researchstack.backbone.step.active.TappingIntervalStep;
 import org.researchstack.backbone.step.active.WalkingTaskStep;
 import org.researchstack.backbone.task.Task;
+import org.researchstack.backbone.utils.LogExt;
 
 import static junit.framework.Assert.*;
 import static org.researchstack.backbone.task.factory.TremorTaskFactory.*;
@@ -28,6 +32,8 @@ import static org.researchstack.backbone.task.factory.TremorTaskFactory.*;
  * The TaskItemFactoryTests will test the deserialization of JSON into their corresponding Task objects
  */
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({LogExt.class})
 public class TaskItemFactoryTests {
 
     private SurveyFactoryHelper helper;
@@ -37,6 +43,7 @@ public class TaskItemFactoryTests {
 
         helper = new SurveyFactoryHelper();
 
+        PowerMockito.mockStatic(LogExt.class);
         PackageManager packageManager = Mockito.mock(PackageManager.class);
         Mockito.when(helper.mockContext.getPackageManager()).thenReturn(packageManager);
     }

--- a/backbone/src/test/java/org/researchstack/backbone/task/factory/AudioTaskTest.java
+++ b/backbone/src/test/java/org/researchstack/backbone/task/factory/AudioTaskTest.java
@@ -23,6 +23,7 @@ import org.researchstack.backbone.result.TaskResult;
 import org.researchstack.backbone.step.AudioTooLoudStep;
 import org.researchstack.backbone.step.Step;
 import org.researchstack.backbone.step.active.CountdownStep;
+import org.researchstack.backbone.step.active.recorder.AudioRecorder;
 import org.researchstack.backbone.step.active.recorder.AudioRecorderSettings;
 import org.researchstack.backbone.task.NavigableOrderedTask;
 
@@ -153,16 +154,16 @@ public class AudioTaskTest {
                 Arrays.asList(new TaskExcludeOption[] {}));
 
         TaskResult taskTooLoudResult = new TaskResult("audiotaskid");
-        TaskResult taskNotTooLoudResult = new TaskResult("audiotaskid");
 
         List<String> stepIds = getAudioStepIdsOneTooLoudCycle();
         Step step = null;
         int i = 0;
         boolean firstCycleComplete = false;
+        AudioRecorder.setLastTotalSampleAvg(AudioTaskFactory.LOUDNESS_THRESHOLD + .1);
         do {
             TaskResult taskResult = taskTooLoudResult;
             if (firstCycleComplete) {
-                taskResult = taskNotTooLoudResult;
+                AudioRecorder.setLastTotalSampleAvg(AudioTaskFactory.LOUDNESS_THRESHOLD - .1);
             }
 
             step = task.getStepAfterStep(step, taskResult);
@@ -173,25 +174,7 @@ public class AudioTaskTest {
                     firstCycleComplete = true;
                 }
 
-                if (step instanceof CountdownStep) {
-                    {
-                        StepResult<Result> tooLoudResult = new StepResult<>(step);
-                        AudioResult audioResult = new AudioResult(AudioRecorderIdentifier);
-                        audioResult.setRollingAverageOfVolume(AudioTaskFactory.LOUDNESS_THRESHOLD + .1);
-                        tooLoudResult.getResults().put(audioResult.getIdentifier(), audioResult);
-                        taskTooLoudResult.getResults().put(tooLoudResult.getIdentifier(), tooLoudResult);
-                    }
-
-                    {
-                        StepResult<Result> notTooLoudResult = new StepResult<>(step);
-                        AudioResult audioResult = new AudioResult(AudioRecorderIdentifier);
-                        audioResult.setRollingAverageOfVolume(AudioTaskFactory.LOUDNESS_THRESHOLD - .1);
-                        notTooLoudResult.getResults().put(audioResult.getIdentifier(), audioResult);
-                        taskNotTooLoudResult.getResults().put(notTooLoudResult.getIdentifier(), notTooLoudResult);
-                    }
-                }
-
-                assertEquals(step.getIdentifier(), stepIds.get(i));
+                assertEquals(stepIds.get(i), step.getIdentifier());
                 i++;
             }
         } while (step != null);
@@ -242,6 +225,7 @@ public class AudioTaskTest {
                 Instruction1StepIdentifier,
                 CountdownStepIdentifier,
                 AudioTooLoudStepIdentifier,
+                Instruction1StepIdentifier,
                 CountdownStepIdentifier,
                 AudioStepIdentifier,
                 ConclusionStepIdentifier));


### PR DESCRIPTION
This PR solves adds support for guaranteed recording when the screen is turned off, or when the activity is destroyed/re-created for whatever reason that the system decided to.

It is important when testing this branch, to debug using this developer option in the Android system settings called "Do not keep activities" that will simulate the scenario of the system destroying your activity in the background like when the screen is off for a long running active step.  Tasks should be tested with that debugging option, and without it.

To accomplish background recording, I moved all recording and TTS functionality to a service called RecorderService.  The logic of this service is very similar to what ActiveStepLayout was doing previously.  Except now, when we needed to call methods in ActiveStepLayout, we send Broadcasts to communicate.  Also, all recorders now have been switched to using the Broadcasts to communicate state updates.

Most of the ActiveStepLayout sub-classes didn't need any changes except for switching to broadcast paradigm.  I tested them all and they work as they did before expected.

The one sub-class that needed significant logic changes was CameraActiveStepLayout.  It enforces that the ActiveStepLayout be destroyed and the flow moved to the previous step, if the screen is turned off, or activity isPaused for any reason.  The Recorder does not get sent to the RecorderService to achieve this, but is simply managed by the ActiveStepLayout like it used to be.

Overall, this is a huge improvement, and from my testing, it works flawlessly with the screen off, in the pocket of the user, when they do long walking tasks. 

