### PR TITLE
LocationRecorder option for relative coordinates

### DIFF
--- a/backbone/build.gradle
+++ b/backbone/build.gradle
@@ -82,7 +82,7 @@ dependencies {
     implementation 'com.android.support:design:26.1.0'
 
     api 'io.reactivex:rxjava:1.3.0'
-    implementation 'com.google.code.gson:gson:2.8.0'
+    implementation 'com.google.code.gson:gson:2.8.2'
 
     implementation 'com.cronutils:cron-utils:3.1.2'
 

--- a/backbone/src/main/java/org/researchstack/backbone/step/active/recorder/LocationRecorderConfig.java
+++ b/backbone/src/main/java/org/researchstack/backbone/step/active/recorder/LocationRecorderConfig.java
@@ -1,24 +1,17 @@
 package org.researchstack.backbone.step.active.recorder;
 
-import android.Manifest;
-
 import org.researchstack.backbone.step.Step;
 
 import java.io.File;
-import java.util.Collections;
-import java.util.List;
-
-/**
- * Created by TheMDP on 2/20/17.
- */
 
 public class LocationRecorderConfig extends RecorderConfig {
-
     public static final long DEFAULT_MIN_TIME = 100;  // 100 milliseconds minimal time change
     public static final long DEFAULT_LOCATION_DISTANCE = 0;    // no min distance
+    public static final boolean DEFAULT_USES_RELATIVE_COORDINATE = false; // default to absolute coordinates
 
     private long minTime;
     private float minDistance;
+    private boolean usesRelativeCoordinates;
 
     /** Default constructor used for serialization/deserialization */
     LocationRecorderConfig() {
@@ -26,9 +19,7 @@ public class LocationRecorderConfig extends RecorderConfig {
     }
 
     public LocationRecorderConfig(String identifier) {
-        super(identifier);
-        minTime     = DEFAULT_MIN_TIME;
-        minDistance = DEFAULT_LOCATION_DISTANCE;
+        this(identifier, DEFAULT_MIN_TIME, DEFAULT_LOCATION_DISTANCE);
     }
 
     /**
@@ -37,13 +28,60 @@ public class LocationRecorderConfig extends RecorderConfig {
      * @param identifier the recorder's identifier
      */
     public LocationRecorderConfig(String identifier, long minTime, float minDistance) {
+        this(identifier, minTime, minDistance, DEFAULT_USES_RELATIVE_COORDINATE);
+    }
+
+    /** Private constructor, for use with builder. */
+    private LocationRecorderConfig(
+            String identifier, long minTime, float minDistance, boolean usesRelativeCoordinates) {
         super(identifier);
         this.minTime = minTime;
         this.minDistance = minDistance;
+        this.usesRelativeCoordinates = usesRelativeCoordinates;
     }
 
     @Override
     public Recorder recorderForStep(Step step, File outputDirectory) {
-        return new LocationRecorder(minTime, minDistance, getIdentifier(), step, outputDirectory);
+        return new LocationRecorder(minTime, minDistance, usesRelativeCoordinates, getIdentifier(),
+                step, outputDirectory);
+    }
+
+    /** LocationRecorderConfig builder. */
+    public static class Builder {
+        private String identifier;
+        private long minTime = DEFAULT_MIN_TIME;
+        private float minDistance = DEFAULT_LOCATION_DISTANCE;
+        private boolean usesRelativeCoordinates = DEFAULT_USES_RELATIVE_COORDINATE;
+
+        public Builder withIdentifier(String identifier) {
+            this.identifier = identifier;
+            return this;
+        }
+
+        public Builder withMinTime(long minTime) {
+            this.minTime = minTime;
+            return this;
+        }
+
+        public Builder withMinDistance(float minDistance) {
+            this.minDistance = minDistance;
+            return this;
+        }
+
+        /**
+         * If this is set to true, the recorder will produce relative GPS coordinates, using the
+         * user's initial position as zero in the relative coordinate system. If this is set to
+         * false, the recorder will produce absolute GPS coordinates.
+         */
+        public Builder withUsesRelativeCoordinates(boolean usesRelativeCoordinates) {
+            this.usesRelativeCoordinates = usesRelativeCoordinates;
+            return this;
+        }
+
+        /** Builds the LocationRecorderConfig. */
+        public LocationRecorderConfig build() {
+            return new LocationRecorderConfig(identifier, minTime, minDistance,
+                    usesRelativeCoordinates);
+        }
     }
 }

--- a/backbone/src/test/java/org/researchstack/backbone/step/active/recorder/LocationRecorderConfigTest.java
+++ b/backbone/src/test/java/org/researchstack/backbone/step/active/recorder/LocationRecorderConfigTest.java
@@ -1,0 +1,79 @@
+package org.researchstack.backbone.step.active.recorder;
+
+import org.junit.Test;
+import org.researchstack.backbone.step.Step;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public class LocationRecorderConfigTest {
+    private static final Step DUMMY_STEP = new Step();
+    private static final File MOCK_OUTPUT_DIRECTORY = mock(File.class);
+    private static final String TEST_IDENTIFIER = "test-identifier";
+    private static final long TEST_MIN_TIME = 1000L;
+    private static final float TEST_MIN_DISTANCE = 10;
+
+    @Test
+    public void constructorWithIdentifier() {
+        LocationRecorderConfig config = new LocationRecorderConfig(TEST_IDENTIFIER);
+        LocationRecorder recorder = (LocationRecorder) config.recorderForStep(DUMMY_STEP,
+                MOCK_OUTPUT_DIRECTORY);
+        assertCommonProps(recorder);
+        assertEquals(TEST_IDENTIFIER, recorder.getIdentifier());
+        assertEquals(LocationRecorderConfig.DEFAULT_MIN_TIME, recorder.getMinTime());
+        assertEquals((double) LocationRecorderConfig.DEFAULT_LOCATION_DISTANCE,
+                recorder.getMinDistance(), 0.001);
+        assertFalse(recorder.getUsesRelativeCoordinates());
+    }
+
+    @Test
+    public void constructorWithIdentifierMinTimeMinDistance() {
+        LocationRecorderConfig config = new LocationRecorderConfig(TEST_IDENTIFIER, TEST_MIN_TIME,
+                TEST_MIN_DISTANCE);
+        LocationRecorder recorder = (LocationRecorder) config.recorderForStep(DUMMY_STEP,
+                MOCK_OUTPUT_DIRECTORY);
+        assertCommonProps(recorder);
+        assertEquals(TEST_IDENTIFIER, recorder.getIdentifier());
+        assertEquals(TEST_MIN_TIME, recorder.getMinTime());
+        assertEquals(TEST_MIN_DISTANCE, recorder.getMinDistance(), 0.001);
+        assertFalse(recorder.getUsesRelativeCoordinates());
+    }
+
+    @Test
+    public void builderDefaults() {
+        LocationRecorderConfig config = new LocationRecorderConfig.Builder().build();
+        LocationRecorder recorder = (LocationRecorder) config.recorderForStep(DUMMY_STEP,
+                MOCK_OUTPUT_DIRECTORY);
+        assertCommonProps(recorder);
+        assertNull(recorder.getIdentifier());
+        assertEquals(LocationRecorderConfig.DEFAULT_MIN_TIME, recorder.getMinTime());
+        assertEquals((double) LocationRecorderConfig.DEFAULT_LOCATION_DISTANCE,
+                recorder.getMinDistance(), 0.001);
+        assertFalse(recorder.getUsesRelativeCoordinates());
+    }
+
+    @Test
+    public void builderWithAllParams() {
+        LocationRecorderConfig config = new LocationRecorderConfig.Builder()
+                .withIdentifier(TEST_IDENTIFIER).withMinTime(TEST_MIN_TIME)
+                .withMinDistance(TEST_MIN_DISTANCE).withUsesRelativeCoordinates(true).build();
+        LocationRecorder recorder = (LocationRecorder) config.recorderForStep(DUMMY_STEP,
+                MOCK_OUTPUT_DIRECTORY);
+        assertCommonProps(recorder);
+        assertEquals(TEST_IDENTIFIER, recorder.getIdentifier());
+        assertEquals(TEST_MIN_TIME, recorder.getMinTime());
+        assertEquals(TEST_MIN_DISTANCE, recorder.getMinDistance(), 0.001);
+        assertTrue(recorder.getUsesRelativeCoordinates());
+    }
+
+    private static void assertCommonProps(LocationRecorder recorder) {
+        assertSame(DUMMY_STEP, recorder.getStep());
+        assertSame(MOCK_OUTPUT_DIRECTORY, recorder.getOutputDirectory());
+    }
+}

--- a/backbone/src/test/java/org/researchstack/backbone/step/active/recorder/LocationRecorderTest.java
+++ b/backbone/src/test/java/org/researchstack/backbone/step/active/recorder/LocationRecorderTest.java
@@ -1,0 +1,170 @@
+package org.researchstack.backbone.step.active.recorder;
+
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.location.Location;
+import android.location.LocationManager;
+import com.google.gson.JsonObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.researchstack.backbone.step.Step;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class LocationRecorderTest {
+    private static final Step DUMMY_STEP = new Step();
+    private static final File MOCK_OUTPUT_DIRECTORY = mock(File.class);
+
+    private Context mockContext;
+    private LocationRecorder recorder;
+    private List<JsonObject> savedJsonList;
+
+    @Before
+    public void setup() {
+        // Set up mocks.
+        LocationManager mockLocationManager = mock(LocationManager.class);
+        when(mockLocationManager.isProviderEnabled(any())).thenReturn(true);
+
+        PackageManager mockPackageManager = mock(PackageManager.class);
+        when(mockPackageManager.checkPermission(any(), any())).thenReturn(
+                PackageManager.PERMISSION_GRANTED);
+
+        mockContext = mock(Context.class);
+        when(mockContext.getSystemService(Context.LOCATION_SERVICE)).thenReturn(
+                mockLocationManager);
+
+        // Init savedJsonList.
+        savedJsonList = new ArrayList<>();
+    }
+
+    @Test
+    public void absoluteCoordinates() {
+        // Setup
+        LocationRecorderConfig config = new LocationRecorderConfig.Builder()
+                .withUsesRelativeCoordinates(false).build();
+        initLocationRecorderFromConfig(config);
+
+        // Start
+        recorder.start(mockContext);
+
+        // First coordinate
+        Location firstLocation = mockLocation(47.5, -122.5);
+        recorder.onLocationChanged(firstLocation);
+
+        // Second coordinate, head northwest 0.1 degrees.
+        Location secondLocation = mockLocation(47.6, -122.6);
+        recorder.onLocationChanged(secondLocation);
+
+        // Stop
+        recorder.stop();
+
+        // Verify saved locations.
+        verify(recorder, times(2)).writeJsonObjectToFile(any());
+
+        assertEquals(savedJsonList.size(), 2);
+        assertAbsoluteCoordinates(47.5, -122.5, savedJsonList
+                .get(0));
+        assertAbsoluteCoordinates(47.6, -122.6, savedJsonList
+                .get(1));
+    }
+
+    @Test
+    public void relativeCoordinates() {
+        // Setup
+        LocationRecorderConfig config = new LocationRecorderConfig.Builder()
+                .withUsesRelativeCoordinates(true).build();
+        initLocationRecorderFromConfig(config);
+
+        // Start
+        recorder.start(mockContext);
+
+        // First coordinate
+        Location firstLocation = mockLocation(47.5, -122.5);
+        recorder.onLocationChanged(firstLocation);
+
+        // Second coordinate, head northwest 0.1 degrees.
+        Location secondLocation = mockLocation(47.6, -122.6);
+        recorder.onLocationChanged(secondLocation);
+
+        // Stop
+        recorder.stop();
+
+        // Verify saved locations.
+        verify(recorder, times(2)).writeJsonObjectToFile(any());
+
+        assertEquals(savedJsonList.size(), 2);
+        assertRelativeCoordinates(0.0, 0.0, savedJsonList
+                .get(0));
+        assertRelativeCoordinates(0.1, -0.1, savedJsonList
+                .get(1));
+    }
+
+    private void initLocationRecorderFromConfig(LocationRecorderConfig config) {
+        // Spy location recorder, so we can prevent things like start/stopJsonDataLogging() from
+        // firing.
+        recorder = spy((LocationRecorder) config.recorderForStep(DUMMY_STEP,
+                MOCK_OUTPUT_DIRECTORY));
+        doNothing().when(recorder).startJsonDataLogging();
+        doNothing().when(recorder).sendLocationUpdateBroadcast(anyDouble(), anyDouble(),
+                anyDouble());
+        doNothing().when(recorder).stopJsonDataLogging();
+
+        // LocationRecorder uses an optimization to re-use JSON objects so we can avoid creating
+        // JSON objects multiple times a second. One side effect is that we need to copy and save
+        // JSON in unit tests, or mock gets really confused.
+        doAnswer(invocation -> {
+            JsonObject savedJson = invocation.getArgument(0);
+            savedJsonList.add(savedJson.deepCopy());
+
+            // Required return statement.
+            return null;
+        }).when(recorder).writeJsonObjectToFile(any());
+    }
+
+    private static Location mockLocation(double latitude, double longitude) {
+        Location location = mock(Location.class);
+        when(location.getLatitude()).thenReturn(latitude);
+        when(location.getLongitude()).thenReturn(longitude);
+        return location;
+    }
+
+    private static void assertAbsoluteCoordinates(
+            double expectedLatitude, double expectedLongitude, JsonObject actualJsonObject) {
+        JsonObject coordinateJsonObject = actualJsonObject.getAsJsonObject(
+                LocationRecorder.COORDINATE_KEY);
+        assertEquals(expectedLatitude, coordinateJsonObject.get(LocationRecorder.LATITUDE_KEY)
+                .getAsDouble(), 0.001);
+        assertEquals(expectedLongitude, coordinateJsonObject.get(LocationRecorder.LONGITUDE_KEY)
+                .getAsDouble(), 0.001);
+        assertFalse(coordinateJsonObject.has(LocationRecorder.RELATIVE_LATITUDE_KEY));
+        assertFalse(coordinateJsonObject.has(LocationRecorder.RELATIVE_LONGITUDE_KEY));
+    }
+
+    private static void assertRelativeCoordinates(
+            double expectedLatitude, double expectedLongitude, JsonObject actualJsonObject) {
+        JsonObject coordinateJsonObject = actualJsonObject.getAsJsonObject(
+                LocationRecorder.COORDINATE_KEY);
+        assertEquals(expectedLatitude,
+                coordinateJsonObject.get(LocationRecorder.RELATIVE_LATITUDE_KEY).getAsDouble(),
+                0.001);
+        assertEquals(expectedLongitude,
+                coordinateJsonObject.get(LocationRecorder.RELATIVE_LONGITUDE_KEY).getAsDouble(),
+                0.001);
+        assertFalse(coordinateJsonObject.has(LocationRecorder.LATITUDE_KEY));
+        assertFalse(coordinateJsonObject.has(LocationRecorder.LONGITUDE_KEY));
+    }
+}


### PR DESCRIPTION
For privacy reasons, provide an option to record relative GPS coordinates, using the user's initial location as "zero".

Testing done:
* Added unit tests
* Tested relative coordinates in CRF Android app