### PR TITLE
Update LocationRecorder timestamps to match iOS ResearchKit

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/step/active/recorder/LocationRecorder.java
+++ b/backbone/src/main/java/org/researchstack/backbone/step/active/recorder/LocationRecorder.java
@@ -10,15 +10,19 @@ import android.location.LocationListener;
 import android.location.LocationManager;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.SystemClock;
 import android.util.Log;
 
 import com.google.gson.JsonObject;
 
 import org.researchstack.backbone.R;
 import org.researchstack.backbone.step.Step;
+import org.researchstack.backbone.utils.FormatHelper;
 
 import java.io.File;
 import java.io.Serializable;
+import java.text.SimpleDateFormat;
+import java.util.Locale;
 
 import static android.content.Context.MODE_PRIVATE;
 
@@ -34,7 +38,6 @@ public class LocationRecorder extends JsonArrayDataRecorder implements LocationL
     private static final String SHARED_PREFS_KEY = "LocationRecorder";
     private static final String LAST_RECORDED_DIST_KEY = "LastRecordedTotalDistance";
 
-    public static final String TIMESTAMP_KEY   = "timestamp";
     public static final String COORDINATE_KEY  = "coordinate";
     public static final String LONGITUDE_KEY   = "longitude";
     public static final String LATITUDE_KEY    = "latitude";
@@ -44,6 +47,9 @@ public class LocationRecorder extends JsonArrayDataRecorder implements LocationL
     public static final String RELATIVE_LATITUDE_KEY = "relativeLatitude";
     public static final String RELATIVE_LONGITUDE_KEY = "relativeLongitude";
     public static final String SPEED_KEY       = "speed";
+    public static final String TIMESTAMP_DATE_KEY = "timestampDate";
+    public static final String TIMESTAMP_IN_SECONDS_KEY = "timestamp";
+    public static final String UPTIME_IN_SECONDS_KEY = "uptime";
 
     private JsonObject jsonObject;
     private JsonObject coordinateJsonObject;
@@ -56,6 +62,7 @@ public class LocationRecorder extends JsonArrayDataRecorder implements LocationL
     private double totalDistance;
     private Location firstLocation;
     private Location lastLocation;
+    private long startTimeNanosSinceBoot;
 
     public static final String BROADCAST_LOCATION_UPDATE_ACTION  = "LocationRecorder_BroadcastLocationUpdate";
     private static final String BROADCAST_LOCATION_UPDATE_KEY    = "LocationUpdate";
@@ -183,8 +190,29 @@ public class LocationRecorder extends JsonArrayDataRecorder implements LocationL
                 firstLocation = location;
             }
 
-            jsonObject.addProperty(TIMESTAMP_KEY, location.getTime());
+            // getElapsedReatimeNanos() is long nanoseconds since system boot time.
+            long locationNanos = getElapsedNanosSinceBootFromLocation(location);
+            if (startTimeNanosSinceBoot == 0) {
+                // Initialize start time.
+                startTimeNanosSinceBoot = locationNanos;
 
+                // Add timestamp date, which is the ISO timestamp representing the activity start time.
+                // Location.getTime() is always epoch milliseconds, so we can use as is.
+                jsonObject.addProperty(TIMESTAMP_DATE_KEY, new SimpleDateFormat(FormatHelper.DATE_FORMAT_ISO_8601,
+                        Locale.getDefault()).format(location.getTime()));
+            } else if (jsonObject.has(TIMESTAMP_DATE_KEY)) {
+                // Because we re-use the jsonObject, we need to clear the timestamp date key after the first iteration.
+                jsonObject.remove(TIMESTAMP_DATE_KEY);
+            }
+
+            // Timestamps
+            // timestamp is seconds since start of the activity (locationNanos minus startTimeNanos, divided by a billion).
+            // uptime is a monotonically increasing timestamp in seconds, with any arbitrary zero. (We use
+            // getElapsedRealtimeNanos(), divided by a billion.)
+            jsonObject.addProperty(TIMESTAMP_IN_SECONDS_KEY, (locationNanos - startTimeNanosSinceBoot) * 1e-9);
+            jsonObject.addProperty(UPTIME_IN_SECONDS_KEY, locationNanos * 1e-9);
+
+            // GPS coordinates
             if (usesRelativeCoordinates) {
                 // Subtract from the firstLocation to get relative coordinates.
                 double relativeLatitude = location.getLatitude() - firstLocation.getLatitude();
@@ -223,6 +251,17 @@ public class LocationRecorder extends JsonArrayDataRecorder implements LocationL
                     location.getLongitude(), location.getLatitude(), totalDistance);
 
             lastLocation = location;
+        }
+    }
+
+    // Wrapper method which encapsulates getting the elapsed realtime nanos, or falls back to elasped realtime (millis)
+    // for older OS versions.
+    // Package-scoped so this can be mocked for unit tests.
+    long getElapsedNanosSinceBootFromLocation(Location location) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            return location.getElapsedRealtimeNanos();
+        } else {
+            return (long) (SystemClock.elapsedRealtime() * 1e6); // millis to nanos
         }
     }
 


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/AA-269

LocationRecorder timestamps should match iOS ResearchKit. See also SensorRecorder.

Testing done:
* updated LocationRecorderTest unit tests
* manually tested in CRF 12MT test

Example output:
```json
[ {
    "timestampDate" : "2018-01-30T00:12:57.646-0800",
    "timestamp" : 0.0,
    "uptime" : 188.590925,
    "coordinate" : {
      "relativeLatitude" : 0.0,
      "relativeLongitude" : 0.0
    },
    "accuracy" : 4.8826256,
    "speed" : 0.5664488,
    "altitude" : 469.1631774902344
  }, {
    "timestamp" : 3.0056860000000003,
    "uptime" : 191.59661100000002,
    "coordinate" : {
      "relativeLatitude" : -1.1151054278712991E-4,
      "relativeLongitude" : 7.309703838132009E-5
    },
    "accuracy" : 2.7315426,
    "speed" : 0.4028013,
    "altitude" : 468.6366882324219
  }, {
    "timestamp" : 6.021582,
    "uptime" : 194.61250700000002,
    "coordinate" : {
      "relativeLatitude" : -6.296741368316816E-6,
      "relativeLongitude" : 1.549984068986987E-4
    },
    "accuracy" : 4.707733,
    "speed" : 0.5326313,
    "altitude" : 468.2004089355469
  } ]
```