### PR TITLE
Added abstract function to get license file

### DIFF
--- a/backbone/src/main/java/org/researchstack/backbone/ResourceManager.java
+++ b/backbone/src/main/java/org/researchstack/backbone/ResourceManager.java
@@ -53,6 +53,14 @@ public abstract class ResourceManager extends ResourcePathManager {
     public abstract Resource getConsentPDF();
 
     /**
+     * This is used to get the licenses associated with your application
+     *
+     * @return a {@link org.researchstack.backbone.ResourcePathManager.Resource} representing an HTML
+     * version of the License file.
+     */
+    public abstract Resource getLicense();
+
+    /**
      * The consent section differs from ResearchKit™ as ResearchStack includes extra
      * documentProperties along with support for quiz steps
      *

--- a/backbone/src/test/java/org/researchstack/backbone/onboarding/MockResourceManager.java
+++ b/backbone/src/test/java/org/researchstack/backbone/onboarding/MockResourceManager.java
@@ -81,6 +81,9 @@ public class MockResourceManager extends ResourceManager {
     }
 
     @Override
+    public Resource getLicense() { return null; }
+
+    @Override
     public Resource getConsentSections() {
         return null;
     }


### PR DESCRIPTION
Added an abstract function so that MpResourceManager (which extends ResourceManager) can access the License html file and display it in the Profile page.