### PR TITLE
Fix/pincode rx crash

### DIFF
--- a/backbone/build.gradle
+++ b/backbone/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'com.neenbedankt.android-apt'
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 
-version = '1.1.2'
+version = '1.1.3'
 
 android {
     compileSdkVersion 23
@@ -13,7 +13,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 23
-        versionCode 6
+        versionCode 7
         versionName version
     }
     buildTypes {

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,9 @@ allprojects {
     repositories {
         jcenter()
         maven {
+            url 'https://maven.google.com'
+        }
+        maven {
             url "https://dl.bintray.com/touchlab/Squeaky"
         }
         maven { url "https://jitpack.io" }

--- a/skin/build.gradle
+++ b/skin/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'me.tatarka.retrolambda'
 apply plugin: 'com.neenbedankt.android-apt'
 apply plugin: 'com.jfrog.bintray'
 
-version = '1.1.2'
+version = '1.1.3'
 
 android {
     compileSdkVersion 23
@@ -17,7 +17,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 23
-        versionCode 6
+        versionCode 7
         versionName version
     }
     buildTypes {


### PR DESCRIPTION
Workaround a platform bug associated with RxBinding, by not using RxBinding: (https://github.com/JakeWharton/RxBinding/issues/192)

Motivation:

We were collecting many crash reports from the pincode screen. After research, it appears that the cause comes from `RxTextView.textChanges`, which is affected by an unfixed platform bug in Android. As a workaround, I've simply replaced `textChanges` with an old-school custom `TextWatcher`